### PR TITLE
Fix ci 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: ci
 on:
   push:
     branches:
-      - main
+      - master
     tags:
       - "v[0-9]+.[0-9]+.[0-9]+"
   pull_request:


### PR DESCRIPTION
#### Summary
- Misnamed the branch in `ci.yml`. I have no preference between the two, but if we want to move to `main` we'll have to get one of the admins to change the default.

#### Ticket Link
- none
