### PR TITLE
[MM-53069] Fix failure to send screen track on Firefox

### DIFF
--- a/lib/rtc_peer.js
+++ b/lib/rtc_peer.js
@@ -128,14 +128,16 @@ export class RTCPeer extends EventEmitter {
         });
     }
     onTrack(ev) {
-        if (this.pc) {
-            // If we are trying to reuse an existing transceiver to receive
-            // the track we may need to activate it back.
+        if (this.pc && ev.track.kind === 'video') {
+            // We force the transceiver direction of the incoming screen track
+            // to be 'sendrecv' so Firefox stops complaining.
+            // In practice the transceiver is only ever going to be used to
+            // receive.
             for (const t of this.pc.getTransceivers()) {
                 if (t.receiver && t.receiver.track === ev.track) {
-                    if (t.direction === 'inactive') {
-                        this.logger.logDebug('reactivating transceiver for track');
-                        t.direction = 'recvonly';
+                    if (t.direction !== 'sendrecv') {
+                        this.logger.logDebug('onTrack: setting transceiver direction for track');
+                        t.direction = 'sendrecv';
                     }
                     break;
                 }
@@ -210,13 +212,14 @@ export class RTCPeer extends EventEmitter {
                     // will default to sendrecv which will cause problems when removing the track.
                     for (const trx of this.pc.getTransceivers()) {
                         if (trx.sender === sender) {
-                            this.logger.logDebug('setting transceiver direction to sendonly');
+                            this.logger.logDebug('addTrack: setting transceiver direction to sendonly');
                             trx.direction = 'sendonly';
                             break;
                         }
                     }
                 }
                 else {
+                    this.logger.logDebug('addTrack: creating new transceiver on send');
                     const trx = this.pc.addTransceiver(track, {
                         direction: 'sendonly',
                         sendEncodings: this.config.simulcast && !isFirefox() ? DefaultSimulcastScreenEncodings : FallbackScreenEncodings,

--- a/src/rtc_peer.ts
+++ b/src/rtc_peer.ts
@@ -143,14 +143,16 @@ export class RTCPeer extends EventEmitter {
     }
 
     private onTrack(ev: RTCTrackEvent) {
-        if (this.pc) {
-            // If we are trying to reuse an existing transceiver to receive
-            // the track we may need to activate it back.
+        if (this.pc && ev.track.kind === 'video') {
+            // We force the transceiver direction of the incoming screen track
+            // to be 'sendrecv' so Firefox stops complaining.
+            // In practice the transceiver is only ever going to be used to
+            // receive.
             for (const t of this.pc.getTransceivers()) {
                 if (t.receiver && t.receiver.track === ev.track) {
-                    if (t.direction === 'inactive') {
-                        this.logger.logDebug('reactivating transceiver for track');
-                        t.direction = 'recvonly';
+                    if (t.direction !== 'sendrecv') {
+                        this.logger.logDebug('onTrack: setting transceiver direction for track');
+                        t.direction = 'sendrecv';
                     }
                     break;
                 }
@@ -230,12 +232,13 @@ export class RTCPeer extends EventEmitter {
                 // will default to sendrecv which will cause problems when removing the track.
                 for (const trx of this.pc.getTransceivers()) {
                     if (trx.sender === sender) {
-                        this.logger.logDebug('setting transceiver direction to sendonly');
+                        this.logger.logDebug('addTrack: setting transceiver direction to sendonly');
                         trx.direction = 'sendonly';
                         break;
                     }
                 }
             } else {
+                this.logger.logDebug('addTrack: creating new transceiver on send');
                 const trx = this.pc.addTransceiver(track, {
                     direction: 'sendonly',
                     sendEncodings: this.config.simulcast && !isFirefox() ? DefaultSimulcastScreenEncodings : FallbackScreenEncodings,


### PR DESCRIPTION
#### Summary

Looks like I was too optimistic in https://github.com/mattermost/calls-common/pull/6. Again it's a disappointment on the WebRTC consistency front from Firefox.

PR fixes an issue that prevented screen sharing from Firefox if some other client already screenshared once.

Will create updating PRs for web and mobile once merged and tagged.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-53069
