### PR TITLE
[MM-54328] CallStateData

### DIFF
--- a/lib/types/types.d.ts
+++ b/lib/types/types.d.ts
@@ -71,7 +71,7 @@ export type UserDismissedNotification = {
     userID: string;
     callID: string;
 };
-export type WebsocketEventData = EmptyData | HelloData | CallStartData | UserDisconnectedData | UserConnectedData | UserMutedUnmutedData | UserVoiceOnOffData | UserScreenOnOffData | UserRaiseUnraiseHandData | EmojiData | UserReactionData | CallHostChangedData | CallRecordingStateData | UserState | UserDismissedNotification;
+export type WebsocketEventData = EmptyData | HelloData | CallStartData | UserDisconnectedData | UserConnectedData | UserMutedUnmutedData | UserVoiceOnOffData | UserScreenOnOffData | UserRaiseUnraiseHandData | EmojiData | UserReactionData | CallHostChangedData | CallRecordingStateData | UserState | UserDismissedNotification | CallStateData;
 export interface Logger {
     logDebug: (...args: unknown[]) => void;
     logErr: (...args: unknown[]) => void;
@@ -112,6 +112,10 @@ export type CallState = {
     dismissed_notification?: {
         [userID: string]: boolean;
     };
+};
+export type CallStateData = {
+    channel_id: string;
+    call: string;
 };
 export type CallChannelState = {
     enabled: boolean;

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -110,7 +110,8 @@ export type WebsocketEventData =
     | CallHostChangedData
     | CallRecordingStateData
     | UserState
-    | UserDismissedNotification;
+    | UserDismissedNotification
+    | CallStateData;
 
 export interface Logger {
     logDebug: (...args: unknown[]) => void;
@@ -154,6 +155,11 @@ export type CallState = {
     host_id: string;
     recording?: CallRecordingState;
     dismissed_notification?: { [userID: string]: boolean };
+}
+
+export type CallStateData = {
+    channel_id: string;
+    call: string;
 }
 
 export type CallChannelState = {


### PR DESCRIPTION
#### Summary

Adding a new `CallStateData` type which is the content of the new `wsEventCallState` websocket event introduced in https://github.com/mattermost/mattermost-plugin-calls/pull/512.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-54328
