### PR TITLE
RTCPeer: implement connection timeout

### DIFF
--- a/lib/rtc_peer.d.ts
+++ b/lib/rtc_peer.d.ts
@@ -9,6 +9,7 @@ export declare class RTCPeer extends EventEmitter {
     private readonly logger;
     private readonly webrtc;
     private pingIntervalID;
+    private connTimeoutID;
     private rtt;
     private makingOffer;
     private candidates;

--- a/lib/rtc_peer.js
+++ b/lib/rtc_peer.js
@@ -10,6 +10,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 import { EventEmitter } from 'events';
 import { isFirefox, getFirefoxVersion } from './utils';
 const rtcConnFailedErr = new Error('rtc connection failed');
+const rtcConnTimeoutMsDefault = 15 * 1000;
 const pingIntervalMs = 1000;
 var SimulcastLevel;
 (function (SimulcastLevel) {
@@ -52,6 +53,12 @@ export class RTCPeer extends EventEmitter {
         this.pc.onconnectionstatechange = () => this.onConnectionStateChange();
         this.pc.ontrack = (ev) => this.onTrack(ev);
         this.connected = false;
+        const connTimeout = config.connTimeoutMs || rtcConnTimeoutMsDefault;
+        this.connTimeoutID = setTimeout(() => {
+            if (!this.connected) {
+                this.emit('error', 'timed out waiting for rtc connection');
+            }
+        }, connTimeout);
         // We create a data channel for two reasons:
         // - Initiate a connection without preemptively adding audio/video tracks.
         // - Calculate transport latency through simple ping/pong sequences.
@@ -89,6 +96,7 @@ export class RTCPeer extends EventEmitter {
         var _a;
         switch ((_a = this.pc) === null || _a === void 0 ? void 0 : _a.connectionState) {
             case 'connected':
+                clearTimeout(this.connTimeoutID);
                 this.connected = true;
                 break;
             case 'failed':
@@ -286,5 +294,6 @@ export class RTCPeer extends EventEmitter {
         this.pc = null;
         this.connected = false;
         clearInterval(this.pingIntervalID);
+        clearTimeout(this.connTimeoutID);
     }
 }

--- a/lib/types/webrtc.d.ts
+++ b/lib/types/webrtc.d.ts
@@ -9,6 +9,7 @@ export type RTCPeerConfig = {
     logger: Logger;
     webrtc?: WebRTC;
     simulcast?: boolean;
+    connTimeoutMs: number;
 };
 export type RTCStats = {
     [key: number]: {

--- a/src/types/webrtc.ts
+++ b/src/types/webrtc.ts
@@ -12,6 +12,7 @@ export type RTCPeerConfig = {
     logger: Logger;
     webrtc?: WebRTC;
     simulcast?: boolean;
+    connTimeoutMs: number;
 }
 
 export type RTCStats = {


### PR DESCRIPTION
#### Summary

We are adding a configurable (default to 15s) timeout for RTC connection so that the widget doesn't get stuck indefinitely in case of networking issues.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-54875
