### PR TITLE
Use RTCPeerConnection.connectionState as source of truth

### DIFF
--- a/lib/rtc_peer.js
+++ b/lib/rtc_peer.js
@@ -93,11 +93,18 @@ export class RTCPeer extends EventEmitter {
         }
     }
     onConnectionStateChange() {
-        var _a;
-        switch ((_a = this.pc) === null || _a === void 0 ? void 0 : _a.connectionState) {
+        var _a, _b;
+        this.logger.logDebug(`RTCPeer: connection state change -> ${(_a = this.pc) === null || _a === void 0 ? void 0 : _a.connectionState}`);
+        switch ((_b = this.pc) === null || _b === void 0 ? void 0 : _b.connectionState) {
             case 'connected':
-                clearTimeout(this.connTimeoutID);
-                this.connected = true;
+                if (!this.connected) {
+                    clearTimeout(this.connTimeoutID);
+                    this.connected = true;
+                    this.emit('connect');
+                }
+                break;
+            case 'closed':
+                this.emit('close');
                 break;
             case 'failed':
                 this.emit('close', rtcConnFailedErr);
@@ -106,18 +113,7 @@ export class RTCPeer extends EventEmitter {
     }
     onICEConnectionStateChange() {
         var _a;
-        switch ((_a = this.pc) === null || _a === void 0 ? void 0 : _a.iceConnectionState) {
-            case 'connected':
-                this.emit('connect');
-                break;
-            case 'failed':
-                this.emit('close', rtcConnFailedErr);
-                break;
-            case 'closed':
-                this.emit('close');
-                break;
-            default:
-        }
+        this.logger.logDebug(`RTCPeer: ICE connection state change -> ${(_a = this.pc) === null || _a === void 0 ? void 0 : _a.iceConnectionState}`);
     }
     onNegotiationNeeded() {
         var _a, _b;
@@ -144,7 +140,7 @@ export class RTCPeer extends EventEmitter {
             for (const t of this.pc.getTransceivers()) {
                 if (t.receiver && t.receiver.track === ev.track) {
                     if (t.direction !== 'sendrecv') {
-                        this.logger.logDebug('onTrack: setting transceiver direction for track');
+                        this.logger.logDebug('RTCPeer.onTrack: setting transceiver direction for track');
                         t.direction = 'sendrecv';
                     }
                     break;
@@ -161,7 +157,7 @@ export class RTCPeer extends EventEmitter {
             }
             const msg = JSON.parse(data);
             if (msg.type === 'offer' && (this.makingOffer || ((_a = this.pc) === null || _a === void 0 ? void 0 : _a.signalingState) !== 'stable')) {
-                this.logger.logDebug('signaling conflict, we are polite, proceeding...');
+                this.logger.logDebug('RTCPeer.signal: signaling conflict, we are polite, proceeding...');
             }
             switch (msg.type) {
                 case 'candidate':
@@ -170,11 +166,11 @@ export class RTCPeer extends EventEmitter {
                     // error. In such case we queue them up to be added later.
                     if (this.pc.remoteDescription && this.pc.remoteDescription.type) {
                         this.pc.addIceCandidate(msg.candidate).catch((err) => {
-                            this.logger.logErr('failed to add candidate', err);
+                            this.logger.logErr('RTCPeer.signal: failed to add candidate', err);
                         });
                     }
                     else {
-                        this.logger.logDebug('received ice candidate before remote description, queuing...');
+                        this.logger.logDebug('RTCPeer.signal: received ice candidate before remote description, queuing...');
                         this.candidates.push(msg.candidate);
                     }
                     break;
@@ -186,9 +182,9 @@ export class RTCPeer extends EventEmitter {
                 case 'answer':
                     yield this.pc.setRemoteDescription(msg);
                     for (const candidate of this.candidates) {
-                        this.logger.logDebug('adding queued ice candidate');
+                        this.logger.logDebug('RTCPeer.signal: adding queued ice candidate');
                         this.pc.addIceCandidate(candidate).catch((err) => {
-                            this.logger.logErr('failed to add candidate', err);
+                            this.logger.logErr('RTCPeer.signal: failed to add candidate', err);
                         });
                     }
                     break;
@@ -220,14 +216,14 @@ export class RTCPeer extends EventEmitter {
                     // will default to sendrecv which will cause problems when removing the track.
                     for (const trx of this.pc.getTransceivers()) {
                         if (trx.sender === sender) {
-                            this.logger.logDebug('addTrack: setting transceiver direction to sendonly');
+                            this.logger.logDebug('RTCPeer.addTrack: setting transceiver direction to sendonly');
                             trx.direction = 'sendonly';
                             break;
                         }
                     }
                 }
                 else {
-                    this.logger.logDebug('addTrack: creating new transceiver on send');
+                    this.logger.logDebug('RTCPeer.addTrack: creating new transceiver on send');
                     const trx = this.pc.addTransceiver(track, {
                         direction: 'sendonly',
                         sendEncodings: this.config.simulcast && !isFirefox() ? DefaultSimulcastScreenEncodings : FallbackScreenEncodings,


### PR DESCRIPTION
#### Summary

PR makes a subtle but potentially significant change in how we track connectivity in `RTCPeer`. In certain cases the ICE connection state can actually skip the `connect` step entirely and reach `completed`, something we didn't really consider.

The newer `RTCPeerConnection.connectionState` is a more accurate as it takes into account the states of both the ICE and DTLS underlying transports. See https://chromestatus.com/feature/6001211660566528 for more details.

Also improving the debug logging in case of future issues.

This **needs** to be tested on mobile which should properly implement the event by now but better be safe than sorry.


