### PR TITLE
[MM-57698] Implement ICE candidate pairs stats

### DIFF
--- a/lib/rtc_monitor.js
+++ b/lib/rtc_monitor.js
@@ -107,7 +107,7 @@ export class RTCMonitor extends EventEmitter {
             // - remote-inbound-rtp: metrics for outgoing RTP media streams as received by the remote endpoint.
             if (report.type === 'candidate-pair' && report.nominated) {
                 if (!candidate || (report.priority && candidate.priority && report.priority > candidate.priority)) {
-                    candidate = newRTCCandidatePairStats(report);
+                    candidate = newRTCCandidatePairStats(report, reports);
                 }
             }
             if (report.type === 'inbound-rtp' && report.kind === 'audio') {

--- a/lib/rtc_stats.d.ts
+++ b/lib/rtc_stats.d.ts
@@ -1,4 +1,4 @@
-import { RTCStats } from './types';
+import { RTCStats, SSRCStats, ICEStats, RTCCandidatePairStats } from './types';
 export declare function newRTCLocalInboundStats(report: any): {
     timestamp: any;
     mid: any;
@@ -21,12 +21,7 @@ export declare function newRTCRemoteInboundStats(report: any): {
     jitter: any;
     roundTripTime: any;
 };
-export declare function newRTCCandidatePairStats(report: any): {
-    timestamp: any;
-    priority: any;
-    packetsSent: any;
-    packetsReceived: any;
-    currentRoundTripTime: any;
-    totalRoundTripTime: any;
-};
+export declare function newRTCCandidatePairStats(report: any, reports: RTCStatsReport): RTCCandidatePairStats;
+export declare function parseSSRCStats(reports: RTCStatsReport): SSRCStats;
+export declare function parseICEStats(reports: RTCStatsReport): ICEStats;
 export declare function parseRTCStats(reports: RTCStatsReport): RTCStats;

--- a/lib/rtc_stats.js
+++ b/lib/rtc_stats.js
@@ -25,17 +25,32 @@ export function newRTCRemoteInboundStats(report) {
         roundTripTime: report.roundTripTime,
     };
 }
-export function newRTCCandidatePairStats(report) {
+export function newRTCCandidatePairStats(report, reports) {
+    let local;
+    let remote;
+    reports.forEach((r) => {
+        if (r.id === report.localCandidateId) {
+            local = r;
+        }
+        else if (r.id === report.remoteCandidateId) {
+            remote = r;
+        }
+    });
     return {
+        id: report.id,
         timestamp: report.timestamp,
         priority: report.priority,
         packetsSent: report.packetsSent,
         packetsReceived: report.packetsReceived,
         currentRoundTripTime: report.currentRoundTripTime,
         totalRoundTripTime: report.totalRoundTripTime,
+        nominated: report.nominated,
+        state: report.state,
+        local,
+        remote,
     };
 }
-export function parseRTCStats(reports) {
+export function parseSSRCStats(reports) {
     const stats = {};
     reports.forEach((report) => {
         if (!report.ssrc) {
@@ -80,4 +95,37 @@ export function parseRTCStats(reports) {
         }
     });
     return stats;
+}
+export function parseICEStats(reports) {
+    const stats = {};
+    reports.forEach((report) => {
+        if (report.type !== 'candidate-pair') {
+            return;
+        }
+        if (!stats[report.state]) {
+            stats[report.state] = [];
+        }
+        stats[report.state].push(newRTCCandidatePairStats(report, reports));
+    });
+    // We sort pairs so that first values are those nominated and/or have the highest priority.
+    for (const pairs of Object.values(stats)) {
+        pairs.sort((a, b) => {
+            var _a, _b;
+            if (a.nominated && !b.nominated) {
+                return -1;
+            }
+            if (b.nominated && !a.nominated) {
+                return 1;
+            }
+            // Highest priority should come first.
+            return ((_a = b.priority) !== null && _a !== void 0 ? _a : 0) - ((_b = a.priority) !== null && _b !== void 0 ? _b : 0);
+        });
+    }
+    return stats;
+}
+export function parseRTCStats(reports) {
+    return {
+        ssrcStats: parseSSRCStats(reports),
+        iceStats: parseICEStats(reports),
+    };
 }

--- a/lib/types/webrtc.d.ts
+++ b/lib/types/webrtc.d.ts
@@ -6,11 +6,18 @@ export type RTCPeerConfig = {
     simulcast?: boolean;
     connTimeoutMs?: number;
 };
-export type RTCStats = {
+export type SSRCStats = {
     [key: number]: {
         local: RTCLocalStats;
         remote: RTCRemoteStats;
     };
+};
+export type ICEStats = {
+    [key: string]: RTCCandidatePairStats[];
+};
+export type RTCStats = {
+    ssrcStats: SSRCStats;
+    iceStats: ICEStats;
 };
 export type RTCLocalStats = {
     in?: RTCLocalInboundStats;
@@ -54,13 +61,23 @@ export type RTCRemoteOutboundStats = {
     packetsSent: number;
     bytesSent: number;
 };
+export type RTCIceCandidateStats = {
+    candidateType: string;
+    protocol: string;
+    port: number;
+};
 export type RTCCandidatePairStats = {
+    id: string;
     timestamp: number;
     priority?: number;
     packetsSent: number;
     packetsReceived: number;
     currentRoundTripTime: number;
     totalRoundTripTime: number;
+    nominated?: boolean;
+    state: RTCStatsIceCandidatePairState;
+    local?: RTCIceCandidateStats;
+    remote?: RTCIceCandidateStats;
 };
 export type RTCMonitorConfig = {
     peer: RTCPeer;

--- a/src/rtc_monitor.ts
+++ b/src/rtc_monitor.ts
@@ -150,7 +150,7 @@ export class RTCMonitor extends EventEmitter {
 
             if (report.type === 'candidate-pair' && report.nominated) {
                 if (!candidate || (report.priority && candidate.priority && report.priority > candidate.priority)) {
-                    candidate = newRTCCandidatePairStats(report);
+                    candidate = newRTCCandidatePairStats(report, reports);
                 }
             }
 

--- a/src/types/webrtc.ts
+++ b/src/types/webrtc.ts
@@ -9,12 +9,21 @@ export type RTCPeerConfig = {
     connTimeoutMs?: number;
 }
 
-export type RTCStats = {
+export type SSRCStats = {
     [key: number]: {
         local: RTCLocalStats;
         remote: RTCRemoteStats;
     }
 }
+
+export type ICEStats = {
+    [key: string]: RTCCandidatePairStats[];
+}
+
+export type RTCStats = {
+    ssrcStats: SSRCStats;
+    iceStats: ICEStats;
+};
 
 export type RTCLocalStats = {
     in?: RTCLocalInboundStats;
@@ -64,13 +73,25 @@ export type RTCRemoteOutboundStats = {
     bytesSent: number;
 }
 
+// This should be in lib.dom.d.ts
+export type RTCIceCandidateStats = {
+    candidateType: string;
+    protocol: string;
+    port: number;
+}
+
 export type RTCCandidatePairStats = {
+    id: string;
     timestamp: number;
     priority?: number;
     packetsSent: number;
     packetsReceived: number;
     currentRoundTripTime: number;
     totalRoundTripTime: number;
+    nominated?: boolean;
+    state: RTCStatsIceCandidatePairState;
+    local?: RTCIceCandidateStats;
+    remote?: RTCIceCandidateStats;
 }
 
 export type RTCMonitorConfig = {


### PR DESCRIPTION
#### Summary

PR adds information about ICE candidate pairs to our parsed stats. This is helpful for collecting more precise connectivity information from the higher level without requiring the user to deal with webrtc internals.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-57698
