### PR TITLE
[MM-57781] GroupCallsAllowed

### DIFF
--- a/lib/types/types.d.ts
+++ b/lib/types/types.d.ts
@@ -124,6 +124,7 @@ export type CallsConfig = {
     EnableLiveCaptions: boolean;
     HostControlsAllowed: boolean;
     EnableAV1: boolean;
+    GroupCallsAllowed: boolean;
     TranscribeAPI: TranscribeAPI;
 };
 export type Reaction = UserReactionData & {

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -177,6 +177,7 @@ export type CallsConfig = {
     EnableLiveCaptions: boolean;
     HostControlsAllowed: boolean;
     EnableAV1: boolean;
+    GroupCallsAllowed: boolean;
 
     // Admin only
     TranscribeAPI: TranscribeAPI;


### PR DESCRIPTION
#### Summary

A new client flag used to control whether calls should be allowed in non-DM channels.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-57781