### PR TITLE
Clear queued candidates

### DIFF
--- a/lib/rtc_peer.d.ts
+++ b/lib/rtc_peer.d.ts
@@ -21,6 +21,7 @@ export declare class RTCPeer extends EventEmitter {
     private onICEConnectionStateChange;
     private onNegotiationNeeded;
     private onTrack;
+    private flushICECandidates;
     signal(data: string): Promise<void>;
     addTrack(track: MediaStreamTrack, stream: MediaStream, opts?: RTCTrackOptions): Promise<void>;
     addStream(stream: MediaStream, opts?: RTCTrackOptions[]): void;

--- a/lib/rtc_peer.js
+++ b/lib/rtc_peer.js
@@ -139,6 +139,17 @@ export class RTCPeer extends EventEmitter {
         }
         this.emit('stream', new MediaStream([ev.track]));
     }
+    flushICECandidates() {
+        var _a;
+        this.logger.logDebug(`RTCPeer.flushICECandidates: flushing ${this.candidates.length} candidates`);
+        for (const candidate of this.candidates) {
+            this.logger.logDebug('RTCPeer.flushICECandidates: adding queued ice candidate');
+            (_a = this.pc) === null || _a === void 0 ? void 0 : _a.addIceCandidate(candidate).catch((err) => {
+                this.logger.logErr('RTCPeer.flushICECandidates: failed to add candidate', err);
+            });
+        }
+        this.candidates = [];
+    }
     signal(data) {
         return __awaiter(this, void 0, void 0, function* () {
             var _a;
@@ -166,16 +177,16 @@ export class RTCPeer extends EventEmitter {
                     break;
                 case 'offer':
                     yield this.pc.setRemoteDescription(msg);
+                    if (this.candidates.length > 0) {
+                        this.flushICECandidates();
+                    }
                     yield this.pc.setLocalDescription();
                     this.emit('answer', this.pc.localDescription);
                     break;
                 case 'answer':
                     yield this.pc.setRemoteDescription(msg);
-                    for (const candidate of this.candidates) {
-                        this.logger.logDebug('RTCPeer.signal: adding queued ice candidate');
-                        this.pc.addIceCandidate(candidate).catch((err) => {
-                            this.logger.logErr('RTCPeer.signal: failed to add candidate', err);
-                        });
+                    if (this.candidates.length > 0) {
+                        this.flushICECandidates();
                     }
                     break;
                 default:
@@ -306,6 +317,7 @@ export class RTCPeer extends EventEmitter {
         this.pc.close();
         this.pc = null;
         this.connected = false;
+        this.candidates = [];
         clearInterval(this.pingIntervalID);
         clearTimeout(this.connTimeoutID);
     }


### PR DESCRIPTION
#### Summary

This is unrelated to the recent issues, but during the investigation, I realized we were not clearing the queued candidates, which meant we'd be adding them over and over again at any re-negotiation.



