### PR TITLE
[MM-56952] Fix potentially erroneous MOS calculation on muted tracks

### DIFF
--- a/lib/rtc_monitor.js
+++ b/lib/rtc_monitor.js
@@ -8,7 +8,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 import { EventEmitter } from 'events';
-import { newRTCLocalInboundStats, newRTCRemoteInboundStats, newRTCCandidatePairStats } from './rtc_stats';
+import { newRTCLocalInboundStats, newRTCLocalOutboundStats, newRTCRemoteInboundStats, newRTCCandidatePairStats } from './rtc_stats';
 export const mosThreshold = 3.5;
 export class RTCMonitor extends EventEmitter {
     constructor(cfg) {
@@ -26,6 +26,7 @@ export class RTCMonitor extends EventEmitter {
         this.intervalID = null;
         this.stats = {
             lastLocalIn: {},
+            lastLocalOut: {},
             lastRemoteIn: {},
         };
     }
@@ -68,7 +69,8 @@ export class RTCMonitor extends EventEmitter {
         }
         return stats;
     }
-    getRemoteInQualityStats(remoteIn) {
+    getRemoteInQualityStats(remoteIn, localOut) {
+        var _a;
         const stats = {};
         let totalTime = 0;
         let totalRTT = 0;
@@ -77,6 +79,9 @@ export class RTCMonitor extends EventEmitter {
         let totalLossRate = 0;
         for (const [ssrc, stat] of Object.entries(remoteIn)) {
             if (!this.stats.lastRemoteIn[ssrc] || stat.timestamp <= this.stats.lastRemoteIn[ssrc].timestamp) {
+                continue;
+            }
+            if (localOut[ssrc].packetsSent === ((_a = this.stats.lastLocalOut[ssrc]) === null || _a === void 0 ? void 0 : _a.packetsSent)) {
                 continue;
             }
             const tsDiff = stat.timestamp - this.stats.lastRemoteIn[ssrc].timestamp;
@@ -96,10 +101,9 @@ export class RTCMonitor extends EventEmitter {
     }
     processStats(reports) {
         const localIn = {};
+        const localOut = {};
         const remoteIn = {};
         let candidate;
-        // Step 0: pre-process the raw reports a bit and turn them into usable
-        // objects.
         reports.forEach((report) => {
             // Collect necessary stats to make further calculations:
             // - candidate-pair: transport level metrics.
@@ -112,6 +116,9 @@ export class RTCMonitor extends EventEmitter {
             }
             if (report.type === 'inbound-rtp' && report.kind === 'audio') {
                 localIn[report.ssrc] = newRTCLocalInboundStats(report);
+            }
+            if (report.type === 'outbound-rtp' && report.kind === 'audio') {
+                localOut[report.ssrc] = newRTCLocalOutboundStats(report);
             }
             if (report.type === 'remote-inbound-rtp' && report.kind === 'audio') {
                 remoteIn[report.ssrc] = newRTCRemoteInboundStats(report);
@@ -131,9 +138,10 @@ export class RTCMonitor extends EventEmitter {
         const localInStats = this.getLocalInQualityStats(localIn);
         // Step 3: if sending any stream, calculate average latency, jitter and
         // loss rate using remote stats.
-        const remoteInStats = this.getRemoteInQualityStats(remoteIn);
+        const remoteInStats = this.getRemoteInQualityStats(remoteIn, localOut);
         // Step 4: cache current stats for calculating deltas on next iteration.
         this.stats.lastLocalIn = Object.assign({}, localIn);
+        this.stats.lastLocalOut = Object.assign({}, localOut);
         this.stats.lastRemoteIn = Object.assign({}, remoteIn);
         if (typeof transportLatency === 'undefined' && typeof remoteInStats.avgLatency === 'undefined') {
             transportLatency = this.peer.getRTT() / 2;
@@ -187,6 +195,7 @@ export class RTCMonitor extends EventEmitter {
     clearCache() {
         this.stats = {
             lastLocalIn: {},
+            lastLocalOut: {},
             lastRemoteIn: {},
         };
     }

--- a/lib/rtc_stats.d.ts
+++ b/lib/rtc_stats.d.ts
@@ -13,6 +13,18 @@ export declare function newRTCLocalInboundStats(report: any): {
     jitter: any;
     jitterBufferDelay: any;
 };
+export declare function newRTCLocalOutboundStats(report: any): {
+    timestamp: any;
+    mid: any;
+    kind: any;
+    packetsSent: any;
+    bytesSent: any;
+    retransmittedPacketsSent: any;
+    retransmittedBytesSent: any;
+    nackCount: any;
+    pliCount: any;
+    targetBitrate: any;
+};
 export declare function newRTCRemoteInboundStats(report: any): {
     timestamp: any;
     kind: any;

--- a/lib/rtc_stats.js
+++ b/lib/rtc_stats.js
@@ -15,6 +15,21 @@ export function newRTCLocalInboundStats(report) {
         jitterBufferDelay: report.jitterBufferDelay,
     };
 }
+export function newRTCLocalOutboundStats(report) {
+    return {
+        timestamp: report.timestamp,
+        // @ts-ignore: mid is missing in current version, we need bump some dependencies to fix this.
+        mid: report.mid,
+        kind: report.kind,
+        packetsSent: report.packetsSent,
+        bytesSent: report.bytesSent,
+        retransmittedPacketsSent: report.retransmittedPacketsSent,
+        retransmittedBytesSent: report.retransmittedBytesSent,
+        nackCount: report.nackCount,
+        pliCount: report.pliCount,
+        targetBitrate: report.targetBitrate,
+    };
+}
 export function newRTCRemoteInboundStats(report) {
     return {
         timestamp: report.timestamp,
@@ -67,19 +82,7 @@ export function parseSSRCStats(reports) {
                 stats[report.ssrc].local.in = newRTCLocalInboundStats(report);
                 break;
             case 'outbound-rtp':
-                stats[report.ssrc].local.out = {
-                    timestamp: report.timestamp,
-                    // @ts-ignore: mid is missing in current version, we need bump some dependencies to fix this.
-                    mid: report.mid,
-                    kind: report.kind,
-                    packetsSent: report.packetsSent,
-                    bytesSent: report.bytesSent,
-                    retransmittedPacketsSent: report.retransmittedPacketsSent,
-                    retransmittedBytesSent: report.retransmittedBytesSent,
-                    nackCount: report.nackCount,
-                    pliCount: report.pliCount,
-                    targetBitrate: report.targetBitrate,
-                };
+                stats[report.ssrc].local.out = newRTCLocalOutboundStats(report);
                 break;
             case 'remote-inbound-rtp':
                 stats[report.ssrc].remote.in = newRTCRemoteInboundStats(report);

--- a/src/rtc_monitor.ts
+++ b/src/rtc_monitor.ts
@@ -1,7 +1,7 @@
 import {EventEmitter} from 'events';
 
-import {Logger, RTCMonitorConfig, RTCLocalInboundStats, RTCRemoteInboundStats, RTCCandidatePairStats} from './types';
-import {newRTCLocalInboundStats, newRTCRemoteInboundStats, newRTCCandidatePairStats} from './rtc_stats';
+import {Logger, RTCMonitorConfig, RTCLocalInboundStats, RTCRemoteInboundStats, RTCLocalOutboundStats, RTCCandidatePairStats} from './types';
+import {newRTCLocalInboundStats, newRTCLocalOutboundStats, newRTCRemoteInboundStats, newRTCCandidatePairStats} from './rtc_stats';
 import {RTCPeer} from './rtc_peer';
 
 export const mosThreshold = 3.5;
@@ -10,12 +10,17 @@ type LocalInboundStatsMap = {
     [key: string]: RTCLocalInboundStats,
 };
 
+type LocalOutboundStatsMap = {
+    [key: string]: RTCLocalOutboundStats,
+};
+
 type RemoteInboundStatsMap = {
     [key: string]: RTCRemoteInboundStats,
 };
 
 type MonitorStatsSample = {
     lastLocalIn: LocalInboundStatsMap,
+    lastLocalOut: LocalOutboundStatsMap,
     lastRemoteIn: RemoteInboundStatsMap,
 };
 
@@ -41,6 +46,7 @@ export class RTCMonitor extends EventEmitter {
         this.intervalID = null;
         this.stats = {
             lastLocalIn: {},
+            lastLocalOut: {},
             lastRemoteIn: {},
         };
     }
@@ -104,7 +110,7 @@ export class RTCMonitor extends EventEmitter {
         return stats;
     }
 
-    private getRemoteInQualityStats(remoteIn: RemoteInboundStatsMap) {
+    private getRemoteInQualityStats(remoteIn: RemoteInboundStatsMap, localOut: LocalOutboundStatsMap) {
         const stats: CallQualityStats = {};
 
         let totalTime = 0;
@@ -114,6 +120,10 @@ export class RTCMonitor extends EventEmitter {
         let totalLossRate = 0;
         for (const [ssrc, stat] of Object.entries(remoteIn)) {
             if (!this.stats.lastRemoteIn[ssrc] || stat.timestamp <= this.stats.lastRemoteIn[ssrc].timestamp) {
+                continue;
+            }
+
+            if (localOut[ssrc].packetsSent === this.stats.lastLocalOut[ssrc]?.packetsSent) {
                 continue;
             }
 
@@ -137,11 +147,9 @@ export class RTCMonitor extends EventEmitter {
 
     private processStats(reports: RTCStatsReport) {
         const localIn: LocalInboundStatsMap = {};
+        const localOut: LocalOutboundStatsMap = {};
         const remoteIn: RemoteInboundStatsMap = {};
         let candidate: RTCCandidatePairStats | undefined;
-
-        // Step 0: pre-process the raw reports a bit and turn them into usable
-        // objects.
         reports.forEach((report: any) => {
             // Collect necessary stats to make further calculations:
             // - candidate-pair: transport level metrics.
@@ -156,6 +164,10 @@ export class RTCMonitor extends EventEmitter {
 
             if (report.type === 'inbound-rtp' && report.kind === 'audio') {
                 localIn[report.ssrc] = newRTCLocalInboundStats(report);
+            }
+
+            if (report.type === 'outbound-rtp' && report.kind === 'audio') {
+                localOut[report.ssrc] = newRTCLocalOutboundStats(report);
             }
 
             if (report.type === 'remote-inbound-rtp' && report.kind === 'audio') {
@@ -181,11 +193,14 @@ export class RTCMonitor extends EventEmitter {
 
         // Step 3: if sending any stream, calculate average latency, jitter and
         // loss rate using remote stats.
-        const remoteInStats = this.getRemoteInQualityStats(remoteIn);
+        const remoteInStats = this.getRemoteInQualityStats(remoteIn, localOut);
 
         // Step 4: cache current stats for calculating deltas on next iteration.
         this.stats.lastLocalIn = {
             ...localIn,
+        };
+        this.stats.lastLocalOut = {
+            ...localOut,
         };
         this.stats.lastRemoteIn = {
             ...remoteIn,
@@ -255,6 +270,7 @@ export class RTCMonitor extends EventEmitter {
     clearCache() {
         this.stats = {
             lastLocalIn: {},
+            lastLocalOut: {},
             lastRemoteIn: {},
         };
     }

--- a/src/rtc_stats.ts
+++ b/src/rtc_stats.ts
@@ -19,6 +19,23 @@ export function newRTCLocalInboundStats(report: any) {
     };
 }
 
+export function newRTCLocalOutboundStats(report: any) {
+    return {
+        timestamp: report.timestamp,
+
+        // @ts-ignore: mid is missing in current version, we need bump some dependencies to fix this.
+        mid: report.mid,
+        kind: report.kind,
+        packetsSent: report.packetsSent,
+        bytesSent: report.bytesSent,
+        retransmittedPacketsSent: report.retransmittedPacketsSent,
+        retransmittedBytesSent: report.retransmittedBytesSent,
+        nackCount: report.nackCount,
+        pliCount: report.pliCount,
+        targetBitrate: report.targetBitrate,
+    };
+}
+
 export function newRTCRemoteInboundStats(report: any) {
     return {
         timestamp: report.timestamp,
@@ -75,20 +92,7 @@ export function parseSSRCStats(reports: RTCStatsReport): SSRCStats {
             stats[report.ssrc].local.in = newRTCLocalInboundStats(report);
             break;
         case 'outbound-rtp':
-            stats[report.ssrc].local.out = {
-                timestamp: report.timestamp,
-
-                // @ts-ignore: mid is missing in current version, we need bump some dependencies to fix this.
-                mid: report.mid,
-                kind: report.kind,
-                packetsSent: report.packetsSent,
-                bytesSent: report.bytesSent,
-                retransmittedPacketsSent: report.retransmittedPacketsSent,
-                retransmittedBytesSent: report.retransmittedBytesSent,
-                nackCount: report.nackCount,
-                pliCount: report.pliCount,
-                targetBitrate: report.targetBitrate,
-            };
+            stats[report.ssrc].local.out = newRTCLocalOutboundStats(report);
             break;
         case 'remote-inbound-rtp':
             stats[report.ssrc].remote.in = newRTCRemoteInboundStats(report);


### PR DESCRIPTION
#### Summary

Fixing another false positive occurrence that was causing the quality degradation banner to appear. If the outbound tracks are muted (i.e., not sending packets), we should not consider them during our calculations.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-56952
