### PR TITLE
[MM-45894] Allow signaling through data channel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
         run: |
           mkdir -p tmp
           npx tsc --outDir tmp
-          diff -r lib tmp
+          diff -x 'setup_jest*' -r lib tmp
           rm -rf tmp
   test:
     runs-on: ubuntu-22.04

--- a/lib/dc_msg.d.ts
+++ b/lib/dc_msg.d.ts
@@ -1,0 +1,7 @@
+import { Encoder, Decoder } from '@msgpack/msgpack';
+import { DCMessageType } from './types';
+export declare function encodeDCMsg(enc: Encoder, msgType: DCMessageType, payload?: any): Uint8Array;
+export declare function decodeDCMsg(dec: Decoder, data: Uint8Array): {
+    mt: unknown;
+    payload: unknown;
+};

--- a/lib/dc_msg.js
+++ b/lib/dc_msg.js
@@ -1,0 +1,41 @@
+import { zlibSync, unzlibSync, strToU8, strFromU8 } from 'fflate';
+import { DCMessageType } from './types';
+export function encodeDCMsg(enc, msgType, payload) {
+    const mt = enc.encode(msgType);
+    if (typeof payload === 'undefined') {
+        return mt;
+    }
+    let pl;
+    if (msgType === DCMessageType.SDP) {
+        pl = enc.encode(zlibSync(strToU8(JSON.stringify(payload))));
+    }
+    else {
+        pl = enc.encode(payload);
+    }
+    // Flat encoding
+    const msg = new Uint8Array(mt.byteLength + pl.byteLength);
+    msg.set(mt);
+    msg.set(pl, mt.byteLength);
+    return msg;
+}
+export function decodeDCMsg(dec, data) {
+    let mt;
+    let payload;
+    let i = 0;
+    // Messages are expected to be flat (no surrounding object).
+    // We also support payload-less messages (e.g. ping/pong).
+    for (const val of dec.decodeMulti(data)) {
+        if (i === 0) {
+            mt = val;
+        }
+        else if (i === 1) {
+            payload = val;
+            break;
+        }
+        i++;
+    }
+    if (mt === DCMessageType.SDP) {
+        payload = strFromU8(unzlibSync(payload));
+    }
+    return { mt, payload };
+}

--- a/lib/rtc_monitor.js
+++ b/lib/rtc_monitor.js
@@ -8,7 +8,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 import { EventEmitter } from 'events';
-import { newRTCLocalInboundStats, newRTCLocalOutboundStats, newRTCRemoteInboundStats, newRTCCandidatePairStats } from './rtc_stats';
+import { newRTCLocalInboundStats, newRTCLocalOutboundStats, newRTCRemoteInboundStats, newRTCRemoteOutboundStats, newRTCCandidatePairStats } from './rtc_stats';
 export const mosThreshold = 3.5;
 export class RTCMonitor extends EventEmitter {
     constructor(cfg) {
@@ -28,6 +28,7 @@ export class RTCMonitor extends EventEmitter {
             lastLocalIn: {},
             lastLocalOut: {},
             lastRemoteIn: {},
+            lastRemoteOut: {},
         };
     }
     start() {
@@ -37,7 +38,7 @@ export class RTCMonitor extends EventEmitter {
         this.logger.logDebug('RTCMonitor: starting');
         this.intervalID = setInterval(this.gatherStats, this.cfg.monitorInterval);
     }
-    getLocalInQualityStats(localIn) {
+    getLocalInQualityStats(localIn, remoteOut) {
         const stats = {};
         let totalTime = 0;
         let totalPacketsReceived = 0;
@@ -53,7 +54,23 @@ export class RTCMonitor extends EventEmitter {
             }
             const tsDiff = stat.timestamp - this.stats.lastLocalIn[ssrc].timestamp;
             const receivedDiff = stat.packetsReceived - this.stats.lastLocalIn[ssrc].packetsReceived;
-            const lostDiff = stat.packetsLost - this.stats.lastLocalIn[ssrc].packetsLost;
+            // Tracking loss on the receiving end is a bit more tricky because packets are
+            // forwarded without much modification by the server so if the sender is having issues, these are
+            // propagated to the receiver side which may believe it's having problems as a consequence.
+            //
+            // What we want to know instead is whether the local side is having issues on the
+            // server -> receiver path rather than sender -> server -> receiver one.
+            // To do this we check for any mismatches in packets sent by the remote and packets
+            // received by us.
+            //
+            // Note: it's expected for local.packetsReceived to be slightly higher than remote.packetsSent
+            // since reports are generated at different times, with the local one likely being more time-accurate.
+            //
+            // Having remote.packetsSent higher than local.packetsReceived is instead a fairly good sign
+            // some packets have been lost in transit.
+            const potentiallyLost = remoteOut[ssrc].packetsSent - stat.packetsReceived;
+            const prevPotentiallyLost = this.stats.lastRemoteOut[ssrc].packetsSent - this.stats.lastLocalIn[ssrc].packetsReceived;
+            const lostDiff = prevPotentiallyLost >= 0 && potentiallyLost > prevPotentiallyLost ? potentiallyLost - prevPotentiallyLost : 0;
             totalTime += tsDiff;
             totalPacketsReceived += receivedDiff;
             totalPacketsLost += lostDiff;
@@ -88,7 +105,7 @@ export class RTCMonitor extends EventEmitter {
             totalTime += tsDiff;
             totalRemoteJitter += stat.jitter;
             totalRTT += stat.roundTripTime;
-            totalLossRate = stat.fractionLost;
+            totalLossRate += stat.fractionLost;
             totalRemoteStats++;
         }
         if (totalRemoteStats > 0) {
@@ -103,6 +120,7 @@ export class RTCMonitor extends EventEmitter {
         const localIn = {};
         const localOut = {};
         const remoteIn = {};
+        const remoteOut = {};
         let candidate;
         reports.forEach((report) => {
             // Collect necessary stats to make further calculations:
@@ -123,6 +141,9 @@ export class RTCMonitor extends EventEmitter {
             if (report.type === 'remote-inbound-rtp' && report.kind === 'audio') {
                 remoteIn[report.ssrc] = newRTCRemoteInboundStats(report);
             }
+            if (report.type === 'remote-outbound-rtp' && report.kind === 'audio') {
+                remoteOut[report.ssrc] = newRTCRemoteOutboundStats(report);
+            }
         });
         if (!candidate) {
             this.logger.logDebug('RTCMonitor: no valid candidate was found');
@@ -135,7 +156,7 @@ export class RTCMonitor extends EventEmitter {
             transportLatency = (candidate.currentRoundTripTime * 1000) / 2;
         }
         // Step 2: if receiving any stream, calculate average jitter and loss rate using local stats.
-        const localInStats = this.getLocalInQualityStats(localIn);
+        const localInStats = this.getLocalInQualityStats(localIn, remoteOut);
         // Step 3: if sending any stream, calculate average latency, jitter and
         // loss rate using remote stats.
         const remoteInStats = this.getRemoteInQualityStats(remoteIn, localOut);
@@ -143,6 +164,7 @@ export class RTCMonitor extends EventEmitter {
         this.stats.lastLocalIn = Object.assign({}, localIn);
         this.stats.lastLocalOut = Object.assign({}, localOut);
         this.stats.lastRemoteIn = Object.assign({}, remoteIn);
+        this.stats.lastRemoteOut = Object.assign({}, remoteOut);
         if (typeof transportLatency === 'undefined' && typeof remoteInStats.avgLatency === 'undefined') {
             transportLatency = this.peer.getRTT() / 2;
         }
@@ -160,6 +182,7 @@ export class RTCMonitor extends EventEmitter {
         // Step 5 (or the magic step): calculate MOS (Mean Opinion Score)
         const mos = this.calculateMOS(latency, jitter, lossRate);
         this.emit('mos', mos);
+        this.peer.handleMetrics(lossRate, jitter / 1000);
         this.logger.logDebug(`RTCMonitor: MOS --> ${mos}`);
     }
     calculateMOS(latency, jitter, lossRate) {
@@ -197,6 +220,7 @@ export class RTCMonitor extends EventEmitter {
             lastLocalIn: {},
             lastLocalOut: {},
             lastRemoteIn: {},
+            lastRemoteOut: {},
         };
     }
 }

--- a/lib/rtc_peer.d.ts
+++ b/lib/rtc_peer.d.ts
@@ -7,6 +7,8 @@ export declare class RTCPeer extends EventEmitter {
     private dc;
     private readonly senders;
     private readonly logger;
+    private enc;
+    private dec;
     private pingIntervalID;
     private connTimeoutID;
     private rtt;
@@ -30,6 +32,7 @@ export declare class RTCPeer extends EventEmitter {
     replaceTrack(oldTrackID: string, newTrack: MediaStreamTrack | null): void;
     removeTrack(trackID: string): void;
     getStats(): Promise<RTCStatsReport>;
+    handleMetrics(lossRate: number, jitter: number): void;
     static getVideoCodec(mimeType: string): Promise<RTCRtpCodecCapability | null>;
     destroy(): void;
 }

--- a/lib/rtc_peer.d.ts
+++ b/lib/rtc_peer.d.ts
@@ -10,10 +10,12 @@ export declare class RTCPeer extends EventEmitter {
     private pingIntervalID;
     private connTimeoutID;
     private rtt;
+    private lastPingTS;
     private makingOffer;
     private candidates;
     connected: boolean;
     constructor(config: RTCPeerConfig);
+    private dcHandler;
     private initPingHandler;
     getRTT(): number;
     private onICECandidate;

--- a/lib/rtc_peer.js
+++ b/lib/rtc_peer.js
@@ -29,6 +29,7 @@ export class RTCPeer extends EventEmitter {
     constructor(config) {
         super();
         this.rtt = 0;
+        this.lastPingTS = 0;
         this.makingOffer = false;
         this.candidates = [];
         this.config = config;
@@ -54,20 +55,27 @@ export class RTCPeer extends EventEmitter {
         // - Calculate transport latency through simple ping/pong sequences.
         // - Use this communication channel for further negotiation (to be implemented).
         this.dc = this.pc.createDataChannel('calls-dc');
+        this.dc.onmessage = (ev) => this.dcHandler(ev);
         this.pingIntervalID = this.initPingHandler();
+        this.logger.logDebug('RTCPeer: created new client', JSON.stringify(config));
+    }
+    dcHandler(ev) {
+        if (ev.data === 'pong' && this.lastPingTS > 0) {
+            this.rtt = (performance.now() - this.lastPingTS) / 1000;
+        }
+        else if (ev.data !== 'pong') {
+            this.logger.logDebug('RTCPeer.dcHandler: received sdp through DC');
+            this.signal(ev.data).catch((err) => {
+                this.logger.logErr('RTCPeer.dcHandler: failed to signal sdp', err);
+            });
+        }
     }
     initPingHandler() {
-        let pingTS = 0;
-        this.dc.onmessage = ({ data }) => {
-            if (data === 'pong' && pingTS > 0) {
-                this.rtt = (performance.now() - pingTS) / 1000;
-            }
-        };
         return setInterval(() => {
             if (this.dc.readyState !== 'open') {
                 return;
             }
-            pingTS = performance.now();
+            this.lastPingTS = performance.now();
             this.dc.send('ping');
         }, pingIntervalMs);
     }
@@ -107,11 +115,25 @@ export class RTCPeer extends EventEmitter {
     }
     onNegotiationNeeded() {
         return __awaiter(this, void 0, void 0, function* () {
-            var _a, _b;
+            var _a, _b, _c, _d;
             try {
                 this.makingOffer = true;
                 yield ((_a = this.pc) === null || _a === void 0 ? void 0 : _a.setLocalDescription());
-                this.emit('offer', (_b = this.pc) === null || _b === void 0 ? void 0 : _b.localDescription);
+                if (this.config.dcSignaling && this.dc.readyState === 'open') {
+                    this.logger.logDebug('connected, sending offer through data channel', (_b = this.pc) === null || _b === void 0 ? void 0 : _b.localDescription);
+                    try {
+                        this.dc.send(JSON.stringify((_c = this.pc) === null || _c === void 0 ? void 0 : _c.localDescription));
+                    }
+                    catch (err) {
+                        this.logger.logErr('failed to send on datachannel', err);
+                    }
+                }
+                else {
+                    if (this.config.dcSignaling) {
+                        this.logger.logDebug('dc not connected, emitting offer', this.dc.readyState);
+                    }
+                    this.emit('offer', (_d = this.pc) === null || _d === void 0 ? void 0 : _d.localDescription);
+                }
             }
             catch (err) {
                 this.emit('error', err);
@@ -181,7 +203,21 @@ export class RTCPeer extends EventEmitter {
                         this.flushICECandidates();
                     }
                     yield this.pc.setLocalDescription();
-                    this.emit('answer', this.pc.localDescription);
+                    if (this.config.dcSignaling && this.dc.readyState === 'open') {
+                        this.logger.logDebug('connected, sending answer through data channel', this.pc.localDescription);
+                        try {
+                            this.dc.send(JSON.stringify(this.pc.localDescription));
+                        }
+                        catch (err) {
+                            this.logger.logErr('failed to send on datachannel', err);
+                        }
+                    }
+                    else {
+                        if (this.config.dcSignaling) {
+                            this.logger.logDebug('dc not connected yet, emitting answer', this.dc.readyState);
+                        }
+                        this.emit('answer', this.pc.localDescription);
+                    }
                     break;
                 case 'answer':
                     yield this.pc.setRemoteDescription(msg);
@@ -320,5 +356,6 @@ export class RTCPeer extends EventEmitter {
         this.candidates = [];
         clearInterval(this.pingIntervalID);
         clearTimeout(this.connTimeoutID);
+        this.dc.onmessage = null;
     }
 }

--- a/lib/rtc_peer.js
+++ b/lib/rtc_peer.js
@@ -8,6 +8,9 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 import { EventEmitter } from 'events';
+import { Encoder, Decoder } from '@msgpack/msgpack';
+import { DCMessageType } from './types';
+import { encodeDCMsg, decodeDCMsg } from './dc_msg';
 import { isFirefox, getFirefoxVersion } from './utils';
 const rtcConnFailedErr = new Error('rtc connection failed');
 const rtcConnTimeoutMsDefault = 15 * 1000;
@@ -43,6 +46,8 @@ export class RTCPeer extends EventEmitter {
         this.pc.oniceconnectionstatechange = () => this.onICEConnectionStateChange();
         this.pc.onconnectionstatechange = () => this.onConnectionStateChange();
         this.pc.ontrack = (ev) => this.onTrack(ev);
+        this.enc = new Encoder();
+        this.dec = new Decoder();
         this.connected = false;
         const connTimeout = config.connTimeoutMs || rtcConnTimeoutMsDefault;
         this.connTimeoutID = setTimeout(() => {
@@ -55,19 +60,32 @@ export class RTCPeer extends EventEmitter {
         // - Calculate transport latency through simple ping/pong sequences.
         // - Use this communication channel for further negotiation (to be implemented).
         this.dc = this.pc.createDataChannel('calls-dc');
+        this.dc.binaryType = 'arraybuffer';
         this.dc.onmessage = (ev) => this.dcHandler(ev);
         this.pingIntervalID = this.initPingHandler();
         this.logger.logDebug('RTCPeer: created new client', JSON.stringify(config));
     }
     dcHandler(ev) {
-        if (ev.data === 'pong' && this.lastPingTS > 0) {
-            this.rtt = (performance.now() - this.lastPingTS) / 1000;
+        try {
+            const { mt, payload } = decodeDCMsg(this.dec, ev.data);
+            switch (mt) {
+                case DCMessageType.Pong:
+                    if (this.lastPingTS > 0) {
+                        this.rtt = (performance.now() - this.lastPingTS) / 1000;
+                    }
+                    break;
+                case DCMessageType.SDP:
+                    this.logger.logDebug('RTCPeer.dcHandler: received sdp dc message');
+                    this.signal(payload).catch((err) => {
+                        this.logger.logErr('RTCPeer.dcHandler: failed to signal sdp', err);
+                    });
+                    break;
+                default:
+                    this.logger.logWarn(`RTCPeer.dcHandler: unexpected dc message type ${mt}`);
+            }
         }
-        else if (ev.data !== 'pong') {
-            this.logger.logDebug('RTCPeer.dcHandler: received sdp through DC');
-            this.signal(ev.data).catch((err) => {
-                this.logger.logErr('RTCPeer.dcHandler: failed to signal sdp', err);
-            });
+        catch (err) {
+            this.logger.logErr('failed to decode dc message', err);
         }
     }
     initPingHandler() {
@@ -76,7 +94,7 @@ export class RTCPeer extends EventEmitter {
                 return;
             }
             this.lastPingTS = performance.now();
-            this.dc.send('ping');
+            this.dc.send(encodeDCMsg(this.enc, DCMessageType.Ping));
         }, pingIntervalMs);
     }
     getRTT() {
@@ -87,6 +105,7 @@ export class RTCPeer extends EventEmitter {
     }
     onICECandidate(ev) {
         if (ev.candidate) {
+            this.logger.logDebug('RTCPeer.onICECandidate: local candidate', JSON.stringify(ev.candidate));
             this.emit('candidate', ev.candidate);
         }
     }
@@ -119,10 +138,11 @@ export class RTCPeer extends EventEmitter {
             try {
                 this.makingOffer = true;
                 yield ((_a = this.pc) === null || _a === void 0 ? void 0 : _a.setLocalDescription());
+                this.logger.logDebug('RTCPeer.onNegotiationNeeded: generated local offer', JSON.stringify((_b = this.pc) === null || _b === void 0 ? void 0 : _b.localDescription));
                 if (this.config.dcSignaling && this.dc.readyState === 'open') {
-                    this.logger.logDebug('connected, sending offer through data channel', (_b = this.pc) === null || _b === void 0 ? void 0 : _b.localDescription);
+                    this.logger.logDebug('connected, sending offer through data channel');
                     try {
-                        this.dc.send(JSON.stringify((_c = this.pc) === null || _c === void 0 ? void 0 : _c.localDescription));
+                        this.dc.send(encodeDCMsg(this.enc, DCMessageType.SDP, (_c = this.pc) === null || _c === void 0 ? void 0 : _c.localDescription));
                     }
                     catch (err) {
                         this.logger.logErr('failed to send on datachannel', err);
@@ -130,7 +150,7 @@ export class RTCPeer extends EventEmitter {
                 }
                 else {
                     if (this.config.dcSignaling) {
-                        this.logger.logDebug('dc not connected, emitting offer', this.dc.readyState);
+                        this.logger.logDebug('dc not connected, emitting offer');
                     }
                     this.emit('offer', (_d = this.pc) === null || _d === void 0 ? void 0 : _d.localDescription);
                 }
@@ -178,6 +198,7 @@ export class RTCPeer extends EventEmitter {
             if (!this.pc) {
                 throw new Error('peer has been destroyed');
             }
+            this.logger.logDebug('RTCPeer.signal: handling remote signaling data', data);
             const msg = JSON.parse(data);
             if (msg.type === 'offer' && (this.makingOffer || ((_a = this.pc) === null || _a === void 0 ? void 0 : _a.signalingState) !== 'stable')) {
                 this.logger.logDebug('RTCPeer.signal: signaling conflict, we are polite, proceeding...');
@@ -203,10 +224,11 @@ export class RTCPeer extends EventEmitter {
                         this.flushICECandidates();
                     }
                     yield this.pc.setLocalDescription();
+                    this.logger.logDebug('RTCPeer.signal: generated local answer', JSON.stringify(this.pc.localDescription));
                     if (this.config.dcSignaling && this.dc.readyState === 'open') {
                         this.logger.logDebug('connected, sending answer through data channel', this.pc.localDescription);
                         try {
-                            this.dc.send(JSON.stringify(this.pc.localDescription));
+                            this.dc.send(encodeDCMsg(this.enc, DCMessageType.SDP, this.pc.localDescription));
                         }
                         catch (err) {
                             this.logger.logErr('failed to send on datachannel', err);
@@ -214,7 +236,7 @@ export class RTCPeer extends EventEmitter {
                     }
                     else {
                         if (this.config.dcSignaling) {
-                            this.logger.logDebug('dc not connected yet, emitting answer', this.dc.readyState);
+                            this.logger.logDebug('dc not connected, emitting answer');
                         }
                         this.emit('answer', this.pc.localDescription);
                     }
@@ -318,6 +340,22 @@ export class RTCPeer extends EventEmitter {
             throw new Error('peer has been destroyed');
         }
         return this.pc.getStats(null);
+    }
+    handleMetrics(lossRate, jitter) {
+        try {
+            if (lossRate >= 0) {
+                this.dc.send(encodeDCMsg(this.enc, DCMessageType.LossRate, lossRate));
+            }
+            if (this.rtt > 0) {
+                this.dc.send(encodeDCMsg(this.enc, DCMessageType.RoundTripTime, this.rtt));
+            }
+            if (jitter > 0) {
+                this.dc.send(encodeDCMsg(this.enc, DCMessageType.Jitter, jitter));
+            }
+        }
+        catch (err) {
+            this.logger.logErr('failed to send metrics through dc', err);
+        }
     }
     static getVideoCodec(mimeType) {
         return __awaiter(this, void 0, void 0, function* () {

--- a/lib/rtc_stats.d.ts
+++ b/lib/rtc_stats.d.ts
@@ -33,6 +33,12 @@ export declare function newRTCRemoteInboundStats(report: any): {
     jitter: any;
     roundTripTime: any;
 };
+export declare function newRTCRemoteOutboundStats(report: any): {
+    timestamp: any;
+    kind: any;
+    packetsSent: any;
+    bytesSent: any;
+};
 export declare function newRTCCandidatePairStats(report: any, reports: RTCStatsReport): RTCCandidatePairStats;
 export declare function parseSSRCStats(reports: RTCStatsReport): SSRCStats;
 export declare function parseICEStats(reports: RTCStatsReport): ICEStats;

--- a/lib/rtc_stats.js
+++ b/lib/rtc_stats.js
@@ -40,6 +40,14 @@ export function newRTCRemoteInboundStats(report) {
         roundTripTime: report.roundTripTime,
     };
 }
+export function newRTCRemoteOutboundStats(report) {
+    return {
+        timestamp: report.timestamp,
+        kind: report.kind,
+        packetsSent: report.packetsSent,
+        bytesSent: report.bytesSent,
+    };
+}
 export function newRTCCandidatePairStats(report, reports) {
     let local;
     let remote;
@@ -88,12 +96,7 @@ export function parseSSRCStats(reports) {
                 stats[report.ssrc].remote.in = newRTCRemoteInboundStats(report);
                 break;
             case 'remote-outbound-rtp':
-                stats[report.ssrc].remote.out = {
-                    timestamp: report.timestamp,
-                    kind: report.kind,
-                    packetsSent: report.packetsSent,
-                    bytesSent: report.bytesSent,
-                };
+                stats[report.ssrc].remote.out = newRTCRemoteOutboundStats(report);
                 break;
         }
     });

--- a/lib/setup_jest.js
+++ b/lib/setup_jest.js
@@ -1,0 +1,4 @@
+import { TextEncoder, TextDecoder } from 'util';
+global.TextEncoder = TextEncoder;
+// @ts-ignore
+global.TextDecoder = TextDecoder;

--- a/lib/types/dc_msg.d.ts
+++ b/lib/types/dc_msg.d.ts
@@ -1,0 +1,12 @@
+export declare enum DCMessageType {
+    Ping = 1,
+    Pong = 2,
+    SDP = 3,
+    LossRate = 4,
+    RoundTripTime = 5,
+    Jitter = 6
+}
+export type DCMessageSDP = Uint8Array;
+export type DCMessageLossRate = number;
+export type DCMessageRoundTripTime = number;
+export type DCMessageJitter = number;

--- a/lib/types/dc_msg.js
+++ b/lib/types/dc_msg.js
@@ -1,0 +1,9 @@
+export var DCMessageType;
+(function (DCMessageType) {
+    DCMessageType[DCMessageType["Ping"] = 1] = "Ping";
+    DCMessageType[DCMessageType["Pong"] = 2] = "Pong";
+    DCMessageType[DCMessageType["SDP"] = 3] = "SDP";
+    DCMessageType[DCMessageType["LossRate"] = 4] = "LossRate";
+    DCMessageType[DCMessageType["RoundTripTime"] = 5] = "RoundTripTime";
+    DCMessageType[DCMessageType["Jitter"] = 6] = "Jitter";
+})(DCMessageType || (DCMessageType = {}));

--- a/lib/types/index.d.ts
+++ b/lib/types/index.d.ts
@@ -1,2 +1,3 @@
 export * from './types';
 export * from './webrtc';
+export * from './dc_msg';

--- a/lib/types/index.js
+++ b/lib/types/index.js
@@ -1,2 +1,3 @@
 export * from './types';
 export * from './webrtc';
+export * from './dc_msg';

--- a/lib/types/types.d.ts
+++ b/lib/types/types.d.ts
@@ -125,6 +125,7 @@ export type CallsConfig = {
     HostControlsAllowed: boolean;
     EnableAV1: boolean;
     GroupCallsAllowed: boolean;
+    EnableDCSignaling: boolean;
     TranscribeAPI: TranscribeAPI;
 };
 export type Reaction = UserReactionData & {

--- a/lib/types/types.d.ts
+++ b/lib/types/types.d.ts
@@ -239,4 +239,5 @@ export type CallsClientJoinData = {
     threadID?: string;
     jobID?: string;
     av1Support?: boolean;
+    dcSignaling?: boolean;
 };

--- a/lib/types/webrtc.d.ts
+++ b/lib/types/webrtc.d.ts
@@ -5,6 +5,7 @@ export type RTCPeerConfig = {
     logger: Logger;
     simulcast?: boolean;
     connTimeoutMs?: number;
+    dcSignaling?: boolean;
 };
 export type SSRCStats = {
     [key: number]: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,10 @@
         "": {
             "name": "@mattermost/calls-common",
             "version": "0.27.2",
+            "dependencies": {
+                "@msgpack/msgpack": "^3.0.0-beta2",
+                "fflate": "^0.8.2"
+            },
             "devDependencies": {
                 "@babel/eslint-parser": "7.19.1",
                 "@babel/preset-env": "7.16.4",
@@ -2699,6 +2703,14 @@
                 "@jridgewell/sourcemap-codec": "1.4.14"
             }
         },
+        "node_modules/@msgpack/msgpack": {
+            "version": "3.0.0-beta2",
+            "resolved": "https://registry.npmjs.org/@msgpack/msgpack/-/msgpack-3.0.0-beta2.tgz",
+            "integrity": "sha512-y+l1PNV0XDyY8sM3YtuMLK5vE3/hkfId+Do8pLo/OPxfxuFAUwcGz3oiiUuV46/aBpwTzZ+mRWVMtlSKbradhw==",
+            "engines": {
+                "node": ">= 14"
+            }
+        },
         "node_modules/@nicolo-ribaudo/eslint-scope-5-internals": {
             "version": "5.1.1-v1",
             "resolved": "https://registry.npmjs.org/@nicolo-ribaudo/eslint-scope-5-internals/-/eslint-scope-5-internals-5.1.1-v1.tgz",
@@ -5162,6 +5174,11 @@
             "dependencies": {
                 "bser": "2.1.1"
             }
+        },
+        "node_modules/fflate": {
+            "version": "0.8.2",
+            "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+            "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A=="
         },
         "node_modules/file-entry-cache": {
             "version": "6.0.1",
@@ -11907,6 +11924,11 @@
                 "@jridgewell/sourcemap-codec": "1.4.14"
             }
         },
+        "@msgpack/msgpack": {
+            "version": "3.0.0-beta2",
+            "resolved": "https://registry.npmjs.org/@msgpack/msgpack/-/msgpack-3.0.0-beta2.tgz",
+            "integrity": "sha512-y+l1PNV0XDyY8sM3YtuMLK5vE3/hkfId+Do8pLo/OPxfxuFAUwcGz3oiiUuV46/aBpwTzZ+mRWVMtlSKbradhw=="
+        },
         "@nicolo-ribaudo/eslint-scope-5-internals": {
             "version": "5.1.1-v1",
             "resolved": "https://registry.npmjs.org/@nicolo-ribaudo/eslint-scope-5-internals/-/eslint-scope-5-internals-5.1.1-v1.tgz",
@@ -13822,6 +13844,11 @@
             "requires": {
                 "bser": "2.1.1"
             }
+        },
+        "fflate": {
+            "version": "0.8.2",
+            "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+            "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A=="
         },
         "file-entry-cache": {
             "version": "6.0.1",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,11 @@
         "webpack": "5.75.0"
     },
     "jest": {
-        "testEnvironment": "jsdom"
+        "testEnvironment": "jsdom",
+        "setupFilesAfterEnv": ["<rootDir>/src/setup_jest.ts"]
+    },
+    "dependencies": {
+        "@msgpack/msgpack": "^3.0.0-beta2",
+        "fflate": "^0.8.2"
     }
 }

--- a/src/dc_msg.test.ts
+++ b/src/dc_msg.test.ts
@@ -1,0 +1,39 @@
+import {expect} from '@jest/globals';
+import {Encoder, Decoder} from '@msgpack/msgpack';
+
+import {DCMessageType} from './types';
+import {encodeDCMsg, decodeDCMsg} from './dc_msg';
+
+describe('dcMsg', () => {
+    const enc = new Encoder();
+    const dec = new Decoder();
+
+    it('ping', () => {
+        const pingMsg = encodeDCMsg(enc, DCMessageType.Ping);
+        expect(pingMsg).toEqual(new Uint8Array([DCMessageType.Ping]));
+
+        const {mt, payload} = decodeDCMsg(dec, pingMsg);
+        expect(mt).toEqual(DCMessageType.Ping);
+        expect(payload).toBeUndefined();
+    });
+
+    it('pong', () => {
+        const pongMsg = encodeDCMsg(enc, DCMessageType.Pong);
+        expect(pongMsg).toEqual(new Uint8Array([DCMessageType.Pong]));
+
+        const {mt, payload} = decodeDCMsg(dec, pongMsg);
+        expect(mt).toEqual(DCMessageType.Pong);
+        expect(payload).toBeUndefined();
+    });
+
+    it('sdp', () => {
+        const sdp = {
+            type: 'offer',
+            sdp: 'sdp',
+        };
+        const sdpMsg = encodeDCMsg(enc, DCMessageType.SDP, sdp);
+        const {mt, payload} = decodeDCMsg(dec, sdpMsg);
+        expect(mt).toEqual(DCMessageType.SDP);
+        expect(JSON.parse(payload)).toEqual(sdp);
+    });
+});

--- a/src/dc_msg.ts
+++ b/src/dc_msg.ts
@@ -1,0 +1,49 @@
+import {Encoder, Decoder} from '@msgpack/msgpack';
+import {zlibSync, unzlibSync, strToU8, strFromU8} from 'fflate';
+
+import {DCMessageType, DCMessageSDP} from './types';
+
+export function encodeDCMsg(enc: Encoder, msgType: DCMessageType, payload?: any) {
+    const mt = enc.encode(msgType);
+    if (typeof payload === 'undefined') {
+        return mt;
+    }
+
+    let pl;
+    if (msgType === DCMessageType.SDP) {
+        pl = enc.encode(zlibSync(strToU8(JSON.stringify(payload))));
+    } else {
+        pl = enc.encode(payload);
+    }
+
+    // Flat encoding
+    const msg = new Uint8Array(mt.byteLength + pl.byteLength);
+    msg.set(mt);
+    msg.set(pl, mt.byteLength);
+
+    return msg;
+}
+
+export function decodeDCMsg(dec: Decoder, data: Uint8Array) {
+    let mt;
+    let payload;
+    let i = 0;
+
+    // Messages are expected to be flat (no surrounding object).
+    // We also support payload-less messages (e.g. ping/pong).
+    for (const val of dec.decodeMulti(data)) {
+        if (i === 0) {
+            mt = val;
+        } else if (i === 1) {
+            payload = val;
+            break;
+        }
+        i++;
+    }
+
+    if (mt === DCMessageType.SDP) {
+        payload = strFromU8(unzlibSync(payload as DCMessageSDP));
+    }
+
+    return {mt, payload};
+}

--- a/src/rtc_monitor.ts
+++ b/src/rtc_monitor.ts
@@ -1,7 +1,7 @@
 import {EventEmitter} from 'events';
 
-import {Logger, RTCMonitorConfig, RTCLocalInboundStats, RTCRemoteInboundStats, RTCLocalOutboundStats, RTCCandidatePairStats} from './types';
-import {newRTCLocalInboundStats, newRTCLocalOutboundStats, newRTCRemoteInboundStats, newRTCCandidatePairStats} from './rtc_stats';
+import {Logger, RTCMonitorConfig, RTCLocalInboundStats, RTCRemoteInboundStats, RTCRemoteOutboundStats, RTCLocalOutboundStats, RTCCandidatePairStats} from './types';
+import {newRTCLocalInboundStats, newRTCLocalOutboundStats, newRTCRemoteInboundStats, newRTCRemoteOutboundStats, newRTCCandidatePairStats} from './rtc_stats';
 import {RTCPeer} from './rtc_peer';
 
 export const mosThreshold = 3.5;
@@ -18,10 +18,15 @@ type RemoteInboundStatsMap = {
     [key: string]: RTCRemoteInboundStats,
 };
 
+type RemoteOutboundStatsMap = {
+    [key: string]: RTCRemoteOutboundStats,
+}
+
 type MonitorStatsSample = {
     lastLocalIn: LocalInboundStatsMap,
     lastLocalOut: LocalOutboundStatsMap,
     lastRemoteIn: RemoteInboundStatsMap,
+    lastRemoteOut: RemoteOutboundStatsMap,
 };
 
 type CallQualityStats = {
@@ -48,6 +53,7 @@ export class RTCMonitor extends EventEmitter {
             lastLocalIn: {},
             lastLocalOut: {},
             lastRemoteIn: {},
+            lastRemoteOut: {},
         };
     }
 
@@ -69,7 +75,7 @@ export class RTCMonitor extends EventEmitter {
         });
     };
 
-    private getLocalInQualityStats(localIn: LocalInboundStatsMap) {
+    private getLocalInQualityStats(localIn: LocalInboundStatsMap, remoteOut: RemoteOutboundStatsMap) {
         const stats: CallQualityStats = {};
 
         let totalTime = 0;
@@ -89,7 +95,24 @@ export class RTCMonitor extends EventEmitter {
 
             const tsDiff = stat.timestamp - this.stats.lastLocalIn[ssrc].timestamp;
             const receivedDiff = stat.packetsReceived - this.stats.lastLocalIn[ssrc].packetsReceived;
-            const lostDiff = stat.packetsLost - this.stats.lastLocalIn[ssrc].packetsLost;
+
+            // Tracking loss on the receiving end is a bit more tricky because packets are
+            // forwarded without much modification by the server so if the sender is having issues, these are
+            // propagated to the receiver side which may believe it's having problems as a consequence.
+            //
+            // What we want to know instead is whether the local side is having issues on the
+            // server -> receiver path rather than sender -> server -> receiver one.
+            // To do this we check for any mismatches in packets sent by the remote and packets
+            // received by us.
+            //
+            // Note: it's expected for local.packetsReceived to be slightly higher than remote.packetsSent
+            // since reports are generated at different times, with the local one likely being more time-accurate.
+            //
+            // Having remote.packetsSent higher than local.packetsReceived is instead a fairly good sign
+            // some packets have been lost in transit.
+            const potentiallyLost = remoteOut[ssrc].packetsSent - stat.packetsReceived;
+            const prevPotentiallyLost = this.stats.lastRemoteOut[ssrc].packetsSent - this.stats.lastLocalIn[ssrc].packetsReceived;
+            const lostDiff = prevPotentiallyLost >= 0 && potentiallyLost > prevPotentiallyLost ? potentiallyLost - prevPotentiallyLost : 0;
 
             totalTime += tsDiff;
             totalPacketsReceived += receivedDiff;
@@ -131,7 +154,7 @@ export class RTCMonitor extends EventEmitter {
             totalTime += tsDiff;
             totalRemoteJitter += stat.jitter;
             totalRTT += stat.roundTripTime;
-            totalLossRate = stat.fractionLost;
+            totalLossRate += stat.fractionLost;
             totalRemoteStats++;
         }
 
@@ -149,6 +172,7 @@ export class RTCMonitor extends EventEmitter {
         const localIn: LocalInboundStatsMap = {};
         const localOut: LocalOutboundStatsMap = {};
         const remoteIn: RemoteInboundStatsMap = {};
+        const remoteOut: RemoteOutboundStatsMap = {};
         let candidate: RTCCandidatePairStats | undefined;
         reports.forEach((report: any) => {
             // Collect necessary stats to make further calculations:
@@ -173,6 +197,10 @@ export class RTCMonitor extends EventEmitter {
             if (report.type === 'remote-inbound-rtp' && report.kind === 'audio') {
                 remoteIn[report.ssrc] = newRTCRemoteInboundStats(report);
             }
+
+            if (report.type === 'remote-outbound-rtp' && report.kind === 'audio') {
+                remoteOut[report.ssrc] = newRTCRemoteOutboundStats(report);
+            }
         });
 
         if (!candidate) {
@@ -189,7 +217,7 @@ export class RTCMonitor extends EventEmitter {
         }
 
         // Step 2: if receiving any stream, calculate average jitter and loss rate using local stats.
-        const localInStats = this.getLocalInQualityStats(localIn);
+        const localInStats = this.getLocalInQualityStats(localIn, remoteOut);
 
         // Step 3: if sending any stream, calculate average latency, jitter and
         // loss rate using remote stats.
@@ -204,6 +232,9 @@ export class RTCMonitor extends EventEmitter {
         };
         this.stats.lastRemoteIn = {
             ...remoteIn,
+        };
+        this.stats.lastRemoteOut = {
+            ...remoteOut,
         };
 
         if (typeof transportLatency === 'undefined' && typeof remoteInStats.avgLatency === 'undefined') {
@@ -227,6 +258,7 @@ export class RTCMonitor extends EventEmitter {
         // Step 5 (or the magic step): calculate MOS (Mean Opinion Score)
         const mos = this.calculateMOS(latency!, jitter, lossRate);
         this.emit('mos', mos);
+        this.peer.handleMetrics(lossRate, jitter / 1000);
         this.logger.logDebug(`RTCMonitor: MOS --> ${mos}`);
     }
 
@@ -272,6 +304,7 @@ export class RTCMonitor extends EventEmitter {
             lastLocalIn: {},
             lastLocalOut: {},
             lastRemoteIn: {},
+            lastRemoteOut: {},
         };
     }
 }

--- a/src/rtc_stats.ts
+++ b/src/rtc_stats.ts
@@ -47,6 +47,15 @@ export function newRTCRemoteInboundStats(report: any) {
     };
 }
 
+export function newRTCRemoteOutboundStats(report: any) {
+    return {
+        timestamp: report.timestamp,
+        kind: report.kind,
+        packetsSent: report.packetsSent,
+        bytesSent: report.bytesSent,
+    };
+}
+
 export function newRTCCandidatePairStats(report: any, reports: RTCStatsReport): RTCCandidatePairStats {
     let local;
     let remote;
@@ -98,12 +107,7 @@ export function parseSSRCStats(reports: RTCStatsReport): SSRCStats {
             stats[report.ssrc].remote.in = newRTCRemoteInboundStats(report);
             break;
         case 'remote-outbound-rtp':
-            stats[report.ssrc].remote.out = {
-                timestamp: report.timestamp,
-                kind: report.kind,
-                packetsSent: report.packetsSent,
-                bytesSent: report.bytesSent,
-            };
+            stats[report.ssrc].remote.out = newRTCRemoteOutboundStats(report);
             break;
         }
     });

--- a/src/setup_jest.ts
+++ b/src/setup_jest.ts
@@ -1,0 +1,6 @@
+import {TextEncoder, TextDecoder} from 'util';
+
+global.TextEncoder = TextEncoder;
+
+// @ts-ignore
+global.TextDecoder = TextDecoder;

--- a/src/types/dc_msg.ts
+++ b/src/types/dc_msg.ts
@@ -1,0 +1,13 @@
+export enum DCMessageType {
+    Ping = 1,
+    Pong,
+    SDP,
+    LossRate,
+    RoundTripTime,
+    Jitter,
+}
+
+export type DCMessageSDP = Uint8Array;
+export type DCMessageLossRate = number;
+export type DCMessageRoundTripTime = number;
+export type DCMessageJitter = number;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,2 +1,3 @@
 export * from './types';
 export * from './webrtc';
+export * from './dc_msg';

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -178,6 +178,7 @@ export type CallsConfig = {
     HostControlsAllowed: boolean;
     EnableAV1: boolean;
     GroupCallsAllowed: boolean;
+    EnableDCSignaling: boolean;
 
     // Admin only
     TranscribeAPI: TranscribeAPI;

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -328,4 +328,5 @@ export type CallsClientJoinData = {
     jobID?: string;
 
     av1Support?: boolean;
+    dcSignaling?: boolean;
 }

--- a/src/types/webrtc.ts
+++ b/src/types/webrtc.ts
@@ -7,6 +7,7 @@ export type RTCPeerConfig = {
     logger: Logger;
     simulcast?: boolean;
     connTimeoutMs?: number;
+    dcSignaling?: boolean;
 }
 
 export type SSRCStats = {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,5 +19,5 @@
             ]
         },
     },
-    "exclude": ["**/node_modules", "lib/**", "tmp/**", "**/*.test.js", "**/*.test.ts"]
+    "exclude": ["**/node_modules", "lib/**", "tmp/**", "**/*.test.js", "**/*.test.ts", "setup_jest*"]
 }


### PR DESCRIPTION
#### Summary

Client-side changes are minor. 

- We check for the flag to be on to decide whether to send offers through the DC. 
- We naturally exclude the very first exchange by checking whether the channel is already connected.
- We add a handler for SDPs coming on the DC.

#### Related PRs

https://github.com/mattermost/mattermost-plugin-calls/pull/865
https://github.com/mattermost/rtcd/pull/156

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-45894

