### PR TITLE
[MM-60561] RTC client metrics

### DIFF
--- a/lib/dc_msg.js
+++ b/lib/dc_msg.js
@@ -2,11 +2,16 @@ import { zlibSync, unzlibSync, strToU8, strFromU8 } from 'fflate';
 import { DCMessageType } from './types';
 export function encodeDCMsg(enc, msgType, payload) {
     const mt = enc.encode(msgType);
-    if (!payload) {
+    if (typeof payload === 'undefined') {
         return mt;
     }
-    const pl = msgType === DCMessageType.SDP ?
-        enc.encode(zlibSync(strToU8(JSON.stringify(payload)))) : enc.encode(JSON.stringify(payload));
+    let pl;
+    if (msgType === DCMessageType.SDP) {
+        pl = enc.encode(zlibSync(strToU8(JSON.stringify(payload))));
+    }
+    else {
+        pl = enc.encode(payload);
+    }
     // Flat encoding
     const msg = new Uint8Array(mt.byteLength + pl.byteLength);
     msg.set(mt);

--- a/lib/rtc_monitor.js
+++ b/lib/rtc_monitor.js
@@ -160,6 +160,7 @@ export class RTCMonitor extends EventEmitter {
         // Step 5 (or the magic step): calculate MOS (Mean Opinion Score)
         const mos = this.calculateMOS(latency, jitter, lossRate);
         this.emit('mos', mos);
+        this.peer.handleMetrics(lossRate, this.peer.getRTT(), jitter);
         this.logger.logDebug(`RTCMonitor: MOS --> ${mos}`);
     }
     calculateMOS(latency, jitter, lossRate) {

--- a/lib/rtc_monitor.js
+++ b/lib/rtc_monitor.js
@@ -8,7 +8,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 import { EventEmitter } from 'events';
-import { newRTCLocalInboundStats, newRTCLocalOutboundStats, newRTCRemoteInboundStats, newRTCCandidatePairStats } from './rtc_stats';
+import { newRTCLocalInboundStats, newRTCLocalOutboundStats, newRTCRemoteInboundStats, newRTCRemoteOutboundStats, newRTCCandidatePairStats } from './rtc_stats';
 export const mosThreshold = 3.5;
 export class RTCMonitor extends EventEmitter {
     constructor(cfg) {
@@ -28,6 +28,7 @@ export class RTCMonitor extends EventEmitter {
             lastLocalIn: {},
             lastLocalOut: {},
             lastRemoteIn: {},
+            lastRemoteOut: {},
         };
     }
     start() {
@@ -37,7 +38,7 @@ export class RTCMonitor extends EventEmitter {
         this.logger.logDebug('RTCMonitor: starting');
         this.intervalID = setInterval(this.gatherStats, this.cfg.monitorInterval);
     }
-    getLocalInQualityStats(localIn) {
+    getLocalInQualityStats(localIn, remoteOut) {
         const stats = {};
         let totalTime = 0;
         let totalPacketsReceived = 0;
@@ -53,7 +54,23 @@ export class RTCMonitor extends EventEmitter {
             }
             const tsDiff = stat.timestamp - this.stats.lastLocalIn[ssrc].timestamp;
             const receivedDiff = stat.packetsReceived - this.stats.lastLocalIn[ssrc].packetsReceived;
-            const lostDiff = stat.packetsLost - this.stats.lastLocalIn[ssrc].packetsLost;
+            // Tracking loss on the receiving end is a bit more tricky because packets are
+            // forwarded without much modification by the server so if the sender is having issues, these are
+            // propagated to the receiver side which may believe it's having problems as a consequence.
+            //
+            // What we want to know instead is whether the local side is having issues on the
+            // server -> receiver path rather than sender -> server -> receiver one.
+            // To do this we check for any mismatches in packets sent by the remote and packets
+            // received by us.
+            //
+            // Note: it's expected for local.packetsReceived to be slightly higher than remote.packetsSent
+            // since reports are generated at different times, with the local one likely being more time-accurate.
+            //
+            // Having remote.packetsSent higher than local.packetsReceived is instead a fairly good sign
+            // some packets have been lost in transit.
+            const potentiallyLost = remoteOut[ssrc].packetsSent - stat.packetsReceived;
+            const prevPotentiallyLost = this.stats.lastRemoteOut[ssrc].packetsSent - this.stats.lastLocalIn[ssrc].packetsReceived;
+            const lostDiff = prevPotentiallyLost >= 0 && potentiallyLost > prevPotentiallyLost ? potentiallyLost - prevPotentiallyLost : 0;
             totalTime += tsDiff;
             totalPacketsReceived += receivedDiff;
             totalPacketsLost += lostDiff;
@@ -88,7 +105,7 @@ export class RTCMonitor extends EventEmitter {
             totalTime += tsDiff;
             totalRemoteJitter += stat.jitter;
             totalRTT += stat.roundTripTime;
-            totalLossRate = stat.fractionLost;
+            totalLossRate += stat.fractionLost;
             totalRemoteStats++;
         }
         if (totalRemoteStats > 0) {
@@ -103,6 +120,7 @@ export class RTCMonitor extends EventEmitter {
         const localIn = {};
         const localOut = {};
         const remoteIn = {};
+        const remoteOut = {};
         let candidate;
         reports.forEach((report) => {
             // Collect necessary stats to make further calculations:
@@ -123,6 +141,9 @@ export class RTCMonitor extends EventEmitter {
             if (report.type === 'remote-inbound-rtp' && report.kind === 'audio') {
                 remoteIn[report.ssrc] = newRTCRemoteInboundStats(report);
             }
+            if (report.type === 'remote-outbound-rtp' && report.kind === 'audio') {
+                remoteOut[report.ssrc] = newRTCRemoteOutboundStats(report);
+            }
         });
         if (!candidate) {
             this.logger.logDebug('RTCMonitor: no valid candidate was found');
@@ -135,7 +156,7 @@ export class RTCMonitor extends EventEmitter {
             transportLatency = (candidate.currentRoundTripTime * 1000) / 2;
         }
         // Step 2: if receiving any stream, calculate average jitter and loss rate using local stats.
-        const localInStats = this.getLocalInQualityStats(localIn);
+        const localInStats = this.getLocalInQualityStats(localIn, remoteOut);
         // Step 3: if sending any stream, calculate average latency, jitter and
         // loss rate using remote stats.
         const remoteInStats = this.getRemoteInQualityStats(remoteIn, localOut);
@@ -143,6 +164,7 @@ export class RTCMonitor extends EventEmitter {
         this.stats.lastLocalIn = Object.assign({}, localIn);
         this.stats.lastLocalOut = Object.assign({}, localOut);
         this.stats.lastRemoteIn = Object.assign({}, remoteIn);
+        this.stats.lastRemoteOut = Object.assign({}, remoteOut);
         if (typeof transportLatency === 'undefined' && typeof remoteInStats.avgLatency === 'undefined') {
             transportLatency = this.peer.getRTT() / 2;
         }
@@ -160,7 +182,7 @@ export class RTCMonitor extends EventEmitter {
         // Step 5 (or the magic step): calculate MOS (Mean Opinion Score)
         const mos = this.calculateMOS(latency, jitter, lossRate);
         this.emit('mos', mos);
-        this.peer.handleMetrics(lossRate, this.peer.getRTT(), jitter);
+        this.peer.handleMetrics(lossRate, jitter / 1000);
         this.logger.logDebug(`RTCMonitor: MOS --> ${mos}`);
     }
     calculateMOS(latency, jitter, lossRate) {
@@ -198,6 +220,7 @@ export class RTCMonitor extends EventEmitter {
             lastLocalIn: {},
             lastLocalOut: {},
             lastRemoteIn: {},
+            lastRemoteOut: {},
         };
     }
 }

--- a/lib/rtc_peer.d.ts
+++ b/lib/rtc_peer.d.ts
@@ -32,7 +32,7 @@ export declare class RTCPeer extends EventEmitter {
     replaceTrack(oldTrackID: string, newTrack: MediaStreamTrack | null): void;
     removeTrack(trackID: string): void;
     getStats(): Promise<RTCStatsReport>;
-    handleMetrics(lossRate: number, rtt: number, jitter: number): void;
+    handleMetrics(lossRate: number, jitter: number): void;
     static getVideoCodec(mimeType: string): Promise<RTCRtpCodecCapability | null>;
     destroy(): void;
 }

--- a/lib/rtc_peer.d.ts
+++ b/lib/rtc_peer.d.ts
@@ -32,6 +32,7 @@ export declare class RTCPeer extends EventEmitter {
     replaceTrack(oldTrackID: string, newTrack: MediaStreamTrack | null): void;
     removeTrack(trackID: string): void;
     getStats(): Promise<RTCStatsReport>;
+    handleMetrics(lossRate: number, rtt: number, jitter: number): void;
     static getVideoCodec(mimeType: string): Promise<RTCRtpCodecCapability | null>;
     destroy(): void;
 }

--- a/lib/rtc_peer.js
+++ b/lib/rtc_peer.js
@@ -341,6 +341,22 @@ export class RTCPeer extends EventEmitter {
         }
         return this.pc.getStats(null);
     }
+    handleMetrics(lossRate, rtt, jitter) {
+        try {
+            if (lossRate >= 0) {
+                this.dc.send(encodeDCMsg(this.enc, DCMessageType.LossRate, lossRate));
+            }
+            if (rtt > 0) {
+                this.dc.send(encodeDCMsg(this.enc, DCMessageType.RoundTripTime, rtt));
+            }
+            if (jitter > 0) {
+                this.dc.send(encodeDCMsg(this.enc, DCMessageType.Jitter, jitter));
+            }
+        }
+        catch (err) {
+            this.logger.logErr('failed to send metrics through dc', err);
+        }
+    }
     static getVideoCodec(mimeType) {
         return __awaiter(this, void 0, void 0, function* () {
             if (RTCRtpReceiver.getCapabilities) {

--- a/lib/rtc_peer.js
+++ b/lib/rtc_peer.js
@@ -341,13 +341,13 @@ export class RTCPeer extends EventEmitter {
         }
         return this.pc.getStats(null);
     }
-    handleMetrics(lossRate, rtt, jitter) {
+    handleMetrics(lossRate, jitter) {
         try {
             if (lossRate >= 0) {
                 this.dc.send(encodeDCMsg(this.enc, DCMessageType.LossRate, lossRate));
             }
-            if (rtt > 0) {
-                this.dc.send(encodeDCMsg(this.enc, DCMessageType.RoundTripTime, rtt));
+            if (this.rtt > 0) {
+                this.dc.send(encodeDCMsg(this.enc, DCMessageType.RoundTripTime, this.rtt));
             }
             if (jitter > 0) {
                 this.dc.send(encodeDCMsg(this.enc, DCMessageType.Jitter, jitter));

--- a/lib/rtc_stats.d.ts
+++ b/lib/rtc_stats.d.ts
@@ -33,6 +33,12 @@ export declare function newRTCRemoteInboundStats(report: any): {
     jitter: any;
     roundTripTime: any;
 };
+export declare function newRTCRemoteOutboundStats(report: any): {
+    timestamp: any;
+    kind: any;
+    packetsSent: any;
+    bytesSent: any;
+};
 export declare function newRTCCandidatePairStats(report: any, reports: RTCStatsReport): RTCCandidatePairStats;
 export declare function parseSSRCStats(reports: RTCStatsReport): SSRCStats;
 export declare function parseICEStats(reports: RTCStatsReport): ICEStats;

--- a/lib/rtc_stats.js
+++ b/lib/rtc_stats.js
@@ -40,6 +40,14 @@ export function newRTCRemoteInboundStats(report) {
         roundTripTime: report.roundTripTime,
     };
 }
+export function newRTCRemoteOutboundStats(report) {
+    return {
+        timestamp: report.timestamp,
+        kind: report.kind,
+        packetsSent: report.packetsSent,
+        bytesSent: report.bytesSent,
+    };
+}
 export function newRTCCandidatePairStats(report, reports) {
     let local;
     let remote;
@@ -88,12 +96,7 @@ export function parseSSRCStats(reports) {
                 stats[report.ssrc].remote.in = newRTCRemoteInboundStats(report);
                 break;
             case 'remote-outbound-rtp':
-                stats[report.ssrc].remote.out = {
-                    timestamp: report.timestamp,
-                    kind: report.kind,
-                    packetsSent: report.packetsSent,
-                    bytesSent: report.bytesSent,
-                };
+                stats[report.ssrc].remote.out = newRTCRemoteOutboundStats(report);
                 break;
         }
     });

--- a/lib/types/dc_msg.d.ts
+++ b/lib/types/dc_msg.d.ts
@@ -1,6 +1,12 @@
 export declare enum DCMessageType {
     Ping = 1,
     Pong = 2,
-    SDP = 3
+    SDP = 3,
+    LossRate = 4,
+    RoundTripTime = 5,
+    Jitter = 6
 }
 export type DCMessageSDP = Uint8Array;
+export type DCMessageLossRate = number;
+export type DCMessageRoundTripTime = number;
+export type DCMessageJitter = number;

--- a/lib/types/dc_msg.js
+++ b/lib/types/dc_msg.js
@@ -3,4 +3,7 @@ export var DCMessageType;
     DCMessageType[DCMessageType["Ping"] = 1] = "Ping";
     DCMessageType[DCMessageType["Pong"] = 2] = "Pong";
     DCMessageType[DCMessageType["SDP"] = 3] = "SDP";
+    DCMessageType[DCMessageType["LossRate"] = 4] = "LossRate";
+    DCMessageType[DCMessageType["RoundTripTime"] = 5] = "RoundTripTime";
+    DCMessageType[DCMessageType["Jitter"] = 6] = "Jitter";
 })(DCMessageType || (DCMessageType = {}));

--- a/src/dc_msg.ts
+++ b/src/dc_msg.ts
@@ -5,12 +5,16 @@ import {DCMessageType, DCMessageSDP} from './types';
 
 export function encodeDCMsg(enc: Encoder, msgType: DCMessageType, payload?: any) {
     const mt = enc.encode(msgType);
-    if (!payload) {
+    if (typeof payload === 'undefined') {
         return mt;
     }
 
-    const pl = msgType === DCMessageType.SDP ?
-        enc.encode(zlibSync(strToU8(JSON.stringify(payload)))) : enc.encode(JSON.stringify(payload));
+    let pl;
+    if (msgType === DCMessageType.SDP) {
+        pl = enc.encode(zlibSync(strToU8(JSON.stringify(payload))));
+    } else {
+        pl = enc.encode(payload);
+    }
 
     // Flat encoding
     const msg = new Uint8Array(mt.byteLength + pl.byteLength);

--- a/src/rtc_monitor.ts
+++ b/src/rtc_monitor.ts
@@ -227,6 +227,7 @@ export class RTCMonitor extends EventEmitter {
         // Step 5 (or the magic step): calculate MOS (Mean Opinion Score)
         const mos = this.calculateMOS(latency!, jitter, lossRate);
         this.emit('mos', mos);
+        this.peer.handleMetrics(lossRate, this.peer.getRTT(), jitter);
         this.logger.logDebug(`RTCMonitor: MOS --> ${mos}`);
     }
 

--- a/src/rtc_peer.ts
+++ b/src/rtc_peer.ts
@@ -378,6 +378,22 @@ export class RTCPeer extends EventEmitter {
         return this.pc.getStats(null);
     }
 
+    public handleMetrics(lossRate: number, rtt: number, jitter: number) {
+        try {
+            if (lossRate >= 0) {
+                this.dc.send(encodeDCMsg(this.enc, DCMessageType.LossRate, lossRate));
+            }
+            if (rtt > 0) {
+                this.dc.send(encodeDCMsg(this.enc, DCMessageType.RoundTripTime, rtt));
+            }
+            if (jitter > 0) {
+                this.dc.send(encodeDCMsg(this.enc, DCMessageType.Jitter, jitter));
+            }
+        } catch (err) {
+            this.logger.logErr('failed to send metrics through dc', err);
+        }
+    }
+
     static async getVideoCodec(mimeType: string) {
         if (RTCRtpReceiver.getCapabilities) {
             const videoCapabilities = await RTCRtpReceiver.getCapabilities('video');

--- a/src/rtc_peer.ts
+++ b/src/rtc_peer.ts
@@ -378,13 +378,13 @@ export class RTCPeer extends EventEmitter {
         return this.pc.getStats(null);
     }
 
-    public handleMetrics(lossRate: number, rtt: number, jitter: number) {
+    public handleMetrics(lossRate: number, jitter: number) {
         try {
             if (lossRate >= 0) {
                 this.dc.send(encodeDCMsg(this.enc, DCMessageType.LossRate, lossRate));
             }
-            if (rtt > 0) {
-                this.dc.send(encodeDCMsg(this.enc, DCMessageType.RoundTripTime, rtt));
+            if (this.rtt > 0) {
+                this.dc.send(encodeDCMsg(this.enc, DCMessageType.RoundTripTime, this.rtt));
             }
             if (jitter > 0) {
                 this.dc.send(encodeDCMsg(this.enc, DCMessageType.Jitter, jitter));

--- a/src/rtc_stats.ts
+++ b/src/rtc_stats.ts
@@ -47,6 +47,15 @@ export function newRTCRemoteInboundStats(report: any) {
     };
 }
 
+export function newRTCRemoteOutboundStats(report: any) {
+    return {
+        timestamp: report.timestamp,
+        kind: report.kind,
+        packetsSent: report.packetsSent,
+        bytesSent: report.bytesSent,
+    };
+}
+
 export function newRTCCandidatePairStats(report: any, reports: RTCStatsReport): RTCCandidatePairStats {
     let local;
     let remote;
@@ -98,12 +107,7 @@ export function parseSSRCStats(reports: RTCStatsReport): SSRCStats {
             stats[report.ssrc].remote.in = newRTCRemoteInboundStats(report);
             break;
         case 'remote-outbound-rtp':
-            stats[report.ssrc].remote.out = {
-                timestamp: report.timestamp,
-                kind: report.kind,
-                packetsSent: report.packetsSent,
-                bytesSent: report.bytesSent,
-            };
+            stats[report.ssrc].remote.out = newRTCRemoteOutboundStats(report);
             break;
         }
     });

--- a/src/types/dc_msg.ts
+++ b/src/types/dc_msg.ts
@@ -2,6 +2,12 @@ export enum DCMessageType {
     Ping = 1,
     Pong,
     SDP,
+    LossRate,
+    RoundTripTime,
+    Jitter,
 }
 
 export type DCMessageSDP = Uint8Array;
+export type DCMessageLossRate = number;
+export type DCMessageRoundTripTime = number;
+export type DCMessageJitter = number;


### PR DESCRIPTION
#### Summary

Adding support for tracking the basic RTC client metrics, namely round-trip time, jitter and loss rate.

Also fixing https://mattermost.atlassian.net/browse/MM-60772 in 9ee3933428ed91b8637baed26e0043947158767e

#### Related PRs

https://github.com/mattermost/rtcd/pull/159

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-60561