### PR TITLE
Acquire signaling lock before initializing transceivers

### DIFF
--- a/lib/rtc_peer.d.ts
+++ b/lib/rtc_peer.d.ts
@@ -5,7 +5,6 @@ export declare class RTCPeer extends EventEmitter {
     private pc;
     private dc;
     private dcNegotiated;
-    private dcNegotiationStarted;
     private dcLockResponseCb;
     private readonly senders;
     private readonly logger;
@@ -32,9 +31,9 @@ export declare class RTCPeer extends EventEmitter {
     private flushICECandidates;
     signal(data: string): Promise<void>;
     addTrack(track: MediaStreamTrack, stream: MediaStream, opts?: RTCTrackOptions): Promise<void>;
-    addStream(stream: MediaStream, opts?: RTCTrackOptions[]): void;
+    addStream(stream: MediaStream, opts?: RTCTrackOptions[]): Promise<void>;
     replaceTrack(oldTrackID: string, newTrack: MediaStreamTrack | null): void;
-    removeTrack(trackID: string): void;
+    removeTrack(trackID: string): Promise<void>;
     getStats(): Promise<RTCStatsReport>;
     handleMetrics(lossRate: number, jitter: number): void;
     static getVideoCodec(mimeType: string): Promise<RTCRtpCodec | null>;

--- a/lib/rtc_peer.js
+++ b/lib/rtc_peer.js
@@ -16,7 +16,7 @@ const rtcConnFailedErr = new Error('rtc connection failed');
 const rtcConnTimeoutMsDefault = 15 * 1000;
 const pingIntervalMs = 1000;
 const signalingLockTimeoutMs = 5000;
-const signalingLockCheckIntervalMs = 100;
+const signalingLockCheckIntervalMs = 50;
 var SimulcastLevel;
 (function (SimulcastLevel) {
     SimulcastLevel["High"] = "h";
@@ -34,7 +34,6 @@ export class RTCPeer extends EventEmitter {
     constructor(config) {
         super();
         this.dcNegotiated = false;
-        this.dcNegotiationStarted = false;
         this.dcLockResponseCb = null;
         this.rtt = 0;
         this.lastPingTS = 0;
@@ -143,15 +142,32 @@ export class RTCPeer extends EventEmitter {
         this.logger.logDebug(`RTCPeer: ICE connection state change -> ${(_a = this.pc) === null || _a === void 0 ? void 0 : _a.iceConnectionState}`);
     }
     grabSignalingLock(timeoutMs) {
+        const start = performance.now();
+        const enqueueLockMsg = () => {
+            setTimeout(() => this.dc.send(encodeDCMsg(this.enc, DCMessageType.Lock)), signalingLockCheckIntervalMs);
+        };
         return new Promise((resolve, reject) => {
-            this.dcLockResponseCb = (aquired) => {
-                this.dcLockResponseCb = null;
-                resolve(aquired);
+            this.dcLockResponseCb = (acquired) => {
+                if (acquired) {
+                    this.logger.logDebug(`RTCPeer.grabSignalingLock: lock acquired in ${Math.round(performance.now() - start)}ms`);
+                    this.dcLockResponseCb = null;
+                    resolve();
+                    return;
+                }
+                // If we failed to acquire the lock we wait and try again. It likely means the server side is in the
+                // process of sending us an offer (or we are).
+                enqueueLockMsg();
             };
             setTimeout(() => {
                 this.dcLockResponseCb = null;
                 reject(new Error('timed out waiting for lock'));
             }, timeoutMs);
+            // If we haven't fully negotiated the data channel or if this isn't ready yet we wait.
+            if (!this.dcNegotiated || this.dc.readyState !== 'open') {
+                this.logger.logDebug('RTCPeer.grabSignalingLock: dc not negotiated or not open, requeing');
+                enqueueLockMsg();
+                return;
+            }
             this.dc.send(encodeDCMsg(this.enc, DCMessageType.Lock));
         });
     }
@@ -161,28 +177,6 @@ export class RTCPeer extends EventEmitter {
             if (!this.pc) {
                 return;
             }
-            // First ever negotiation is for establishing the data channel which is then used for further synchronization.
-            if (!this.dcNegotiationStarted) {
-                this.dcNegotiationStarted = true;
-                this.makeOffer();
-                return;
-            }
-            // If we haven't fully negotiated the data channel or if this isn't ready yet we wait.
-            if (!this.dcNegotiated || this.dc.readyState !== 'open') {
-                this.logger.logDebug('RTCPeer.onNegotiationNeeded: dc not negotiated or not open, requeing');
-                setTimeout(() => this.onNegotiationNeeded(), signalingLockCheckIntervalMs);
-                return;
-            }
-            const locked = yield this.grabSignalingLock(signalingLockTimeoutMs);
-            // If we failed to acquire the lock we wait and try again. It means the server side is in the
-            // process of sending us an offer.
-            if (!locked) {
-                this.logger.logDebug('RTCPeer.onNegotiationNeeded: signaling locked not acquired, requeing');
-                setTimeout(() => this.onNegotiationNeeded(), signalingLockCheckIntervalMs);
-                return;
-            }
-            // Lock acquired, we can now proceed with making the offer.
-            this.logger.logDebug('RTCPeer.onNegotiationNeeded: signaling locked acquired');
             yield this.makeOffer();
         });
     }
@@ -325,6 +319,10 @@ export class RTCPeer extends EventEmitter {
             if (!this.pc) {
                 throw new Error('peer has been destroyed');
             }
+            // We need to acquire a signaling lock before we can proceed with adding the track.
+            yield this.grabSignalingLock(signalingLockTimeoutMs);
+            // Lock acquired, we can now proceed.
+            this.logger.logDebug('RTCPeer.addTrack: signaling locked acquired');
             let sender;
             if (track.kind === 'video') {
                 // Simulcast
@@ -354,11 +352,20 @@ export class RTCPeer extends EventEmitter {
         });
     }
     addStream(stream, opts) {
-        stream.getTracks().forEach((track, idx) => {
-            this.addTrack(track, stream, opts === null || opts === void 0 ? void 0 : opts[idx]);
+        return __awaiter(this, void 0, void 0, function* () {
+            for (let idx = 0; idx < stream.getTracks().length; idx++) {
+                const track = stream.getTracks()[idx];
+                // We actually mean to block and add them in order.
+                // eslint-disable-next-line no-await-in-loop
+                yield this.addTrack(track, stream, opts === null || opts === void 0 ? void 0 : opts[idx]);
+            }
         });
     }
     replaceTrack(oldTrackID, newTrack) {
+        if (!this.pc) {
+            throw new Error('peer has been destroyed');
+        }
+        // Since we expect replaceTrack not to cause a re-negotiation, locking is not required.
         const senders = this.senders[oldTrackID];
         if (!senders) {
             throw new Error('senders for track not found');
@@ -372,17 +379,23 @@ export class RTCPeer extends EventEmitter {
         }
     }
     removeTrack(trackID) {
-        if (!this.pc) {
-            throw new Error('peer has been destroyed');
-        }
-        const senders = this.senders[trackID];
-        if (!senders) {
-            throw new Error('senders for track not found');
-        }
-        for (const sender of senders) {
-            this.pc.removeTrack(sender);
-        }
-        delete this.senders[trackID];
+        return __awaiter(this, void 0, void 0, function* () {
+            if (!this.pc) {
+                throw new Error('peer has been destroyed');
+            }
+            // We need to acquire the signaling lock before we can proceed with removing the track.
+            yield this.grabSignalingLock(signalingLockTimeoutMs);
+            // Lock acquired, we can now proceed.
+            this.logger.logDebug('RTCPeer.removeTrack: signaling locked acquired');
+            const senders = this.senders[trackID];
+            if (!senders) {
+                throw new Error('senders for track not found');
+            }
+            for (const sender of senders) {
+                this.pc.removeTrack(sender);
+            }
+            delete this.senders[trackID];
+        });
     }
     getStats() {
         if (!this.pc) {

--- a/src/rtc_peer.test.ts
+++ b/src/rtc_peer.test.ts
@@ -14,8 +14,8 @@ describe('RTCPeer', () => {
 
     beforeEach(() => {
         // Setup mocks for dc_msg
-        (dcMsg.encodeDCMsg as jest.Mock).mockReturnValue(new Uint8Array([1]));
-        (dcMsg.decodeDCMsg as jest.Mock).mockImplementation(() => ({}));
+        jest.mocked(dcMsg.encodeDCMsg).mockReturnValue(new Uint8Array([1]));
+        jest.mocked(dcMsg.encodeDCMsg).mockImplementation(() => ({}));
 
         // Mock RTCPeerConnection
         mockPC = {

--- a/src/rtc_peer.test.ts
+++ b/src/rtc_peer.test.ts
@@ -1,0 +1,191 @@
+import {expect, describe, it, beforeEach, afterEach} from '@jest/globals';
+
+import {RTCPeer} from './rtc_peer';
+import * as dcMsg from './dc_msg';
+
+// Mock the dc_msg module
+jest.mock('./dc_msg');
+
+describe('RTCPeer', () => {
+    let peer: RTCPeer;
+    let mockConfig: RTCPeerConfig;
+    let mockPC: RTCPeerConnection;
+    let mockDC: RTCDataChannel;
+
+    beforeEach(() => {
+        // Setup mocks for dc_msg
+        (dcMsg.encodeDCMsg as jest.Mock).mockReturnValue(new Uint8Array([1]));
+        (dcMsg.decodeDCMsg as jest.Mock).mockImplementation(() => ({}));
+
+        // Mock RTCPeerConnection
+        mockPC = {
+            createDataChannel: jest.fn(),
+            onnegotiationneeded: null,
+            onicecandidate: null,
+            oniceconnectionstatechange: null,
+            onconnectionstatechange: null,
+            ontrack: null,
+            close: jest.fn(),
+        };
+
+        // Mock DataChannel
+        mockDC = {
+            readyState: 'open',
+            binaryType: 'arraybuffer',
+            onmessage: null,
+            send: jest.fn(),
+        };
+
+        // Mock logger
+        const mockLogger = {
+            logDebug: jest.fn(),
+            logErr: jest.fn(),
+            logWarn: jest.fn(),
+            logInfo: jest.fn(),
+        };
+
+        mockConfig = {
+            iceServers: [],
+            logger: mockLogger,
+            simulcast: false,
+            dcSignaling: true,
+        };
+
+        // Mock RTCPeerConnection constructor
+        global.RTCPeerConnection = jest.fn().mockImplementation(() => mockPC);
+        mockPC.createDataChannel.mockReturnValue(mockDC);
+
+        // Mock setInterval and setTimeout
+        jest.useFakeTimers();
+
+        // Create RTCPeer instance
+        peer = new RTCPeer(mockConfig);
+
+        // Expose private properties for testing
+        peer.dc = mockDC;
+        peer.dcNegotiated = true;
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+        jest.useRealTimers();
+    });
+
+    describe('grabSignalingLock', () => {
+        it('should resolve when lock is acquired', async () => {
+            // Setup the test to simulate a successful lock acquisition
+            const lockPromise = peer.grabSignalingLock(1000);
+
+            // Simulate the server responding with a successful lock acquisition
+            const dcLockResponseCb = peer.dcLockResponseCb;
+            expect(dcLockResponseCb).toBeTruthy();
+
+            // Verify that the lock request was sent
+            expect(mockDC.send).toHaveBeenCalledTimes(1);
+
+            // Simulate server response (lock acquired)
+            dcLockResponseCb(true);
+
+            // Wait for the promise to resolve
+            await expect(lockPromise).resolves.toBeUndefined();
+
+            // Verify that the callback was cleared
+            expect(peer.dcLockResponseCb).toBeNull();
+        });
+
+        it('should retry when lock is not acquired', async () => {
+            // Setup the test
+            const lockPromise = peer.grabSignalingLock(1000);
+
+            // Get the callback
+            const dcLockResponseCb = peer.dcLockResponseCb;
+
+            // Simulate server response (lock not acquired)
+            dcLockResponseCb(false);
+
+            // Fast-forward timers to trigger the retry
+            jest.advanceTimersByTime(50);
+
+            // Verify that another lock request was sent
+            expect(mockDC.send).toHaveBeenCalledTimes(2);
+
+            // Now simulate a successful lock acquisition
+            dcLockResponseCb(true);
+
+            // Wait for the promise to resolve
+            await expect(lockPromise).resolves.toBeUndefined();
+        });
+
+        it('should reject when timeout occurs', async () => {
+            // Setup the test
+            const lockPromise = peer.grabSignalingLock(1000);
+
+            // Fast-forward timers to trigger the timeout
+            jest.advanceTimersByTime(1000);
+
+            // Wait for the promise to reject
+            await expect(lockPromise).rejects.toThrow('timed out waiting for lock');
+
+            // Verify that the callback was cleared
+            expect(peer.dcLockResponseCb).toBeNull();
+        });
+
+        it('should queue lock request when data channel is not ready', async () => {
+            // Set data channel to not ready
+            mockDC.readyState = 'connecting';
+
+            // Setup the test
+            const lockPromise = peer.grabSignalingLock(1000);
+
+            // Verify that no lock request was sent immediately
+            expect(mockDC.send).not.toHaveBeenCalled();
+
+            // Fast-forward timers to trigger the retry
+            jest.advanceTimersByTime(50);
+
+            // Verify that a lock request was queued
+            expect(mockDC.send).toHaveBeenCalledTimes(1);
+
+            // Now set data channel to ready and simulate a successful lock acquisition
+            mockDC.readyState = 'open';
+
+            // Get the callback
+            const dcLockResponseCb = peer.dcLockResponseCb;
+
+            // Simulate server response (lock acquired)
+            dcLockResponseCb(true);
+
+            // Wait for the promise to resolve
+            await expect(lockPromise).resolves.toBeUndefined();
+        });
+
+        it('should queue lock request when data channel is not negotiated', async () => {
+            // Set data channel to not negotiated
+            peer.dcNegotiated = false;
+
+            // Setup the test
+            const lockPromise = peer.grabSignalingLock(1000);
+
+            // Verify that no lock request was sent immediately
+            expect(mockDC.send).not.toHaveBeenCalled();
+
+            // Fast-forward timers to trigger the retry
+            jest.advanceTimersByTime(50);
+
+            // Verify that a lock request was queued
+            expect(mockDC.send).toHaveBeenCalledTimes(1);
+
+            // Now set data channel to negotiated and simulate a successful lock acquisition
+            peer.dcNegotiated = true;
+
+            // Get the callback
+            const dcLockResponseCb = peer.dcLockResponseCb;
+
+            // Simulate server response (lock acquired)
+            dcLockResponseCb(true);
+
+            // Wait for the promise to resolve
+            await expect(lockPromise).resolves.toBeUndefined();
+        });
+    });
+});


### PR DESCRIPTION
#### Summary

This was quite an interesting issue, which I wasn't able to reproduce through countless manual attempts, but for some reason, an e2e test I created for the video in DMs work was able to hit this with some surprising consistency.

I am still unsure if the issue is on the JS (browser) side or RTCD (pion), but the problem was that the transceiver direction was getting messed up (server answering `sendrecv` to a `sendonly` offer), resulting in a failure to correctly receive a video track.

The fix is to slightly increase the scope of our locked section to also include any change to the internal peer connection state. In practice this means we should lock before adding tracks rather than as a result of the `onNegotiationNeeded` callback firing because at that point it's too late since transceivers have been created already.

To achieve this I reworked the `grabSignalingLock` logic to block until acquired (or timed out). Also adding some unit tests which Aider was able to get mostly right.




