### PR TITLE
[MM-63430] Calls 1-1 video support (MVP)

### DIFF
--- a/lib/rtc_peer.d.ts
+++ b/lib/rtc_peer.d.ts
@@ -17,6 +17,7 @@ export declare class RTCPeer extends EventEmitter {
     private makingOffer;
     private candidates;
     connected: boolean;
+    private mediaMap;
     constructor(config: RTCPeerConfig);
     private dcHandler;
     private initPingHandler;

--- a/lib/rtc_peer.js
+++ b/lib/rtc_peer.js
@@ -39,6 +39,7 @@ export class RTCPeer extends EventEmitter {
         this.lastPingTS = 0;
         this.makingOffer = false;
         this.candidates = [];
+        this.mediaMap = {};
         this.config = config;
         this.logger = config.logger;
         // We keep a map of track IDs -> RTP sender so that we can easily
@@ -88,6 +89,10 @@ export class RTCPeer extends EventEmitter {
                 case DCMessageType.Lock:
                     this.logger.logDebug('RTCPeer.dcHandler: received lock response', payload);
                     (_a = this.dcLockResponseCb) === null || _a === void 0 ? void 0 : _a.call(this, payload);
+                    break;
+                case DCMessageType.MediaMap:
+                    this.logger.logDebug('RTCPeer.dcHandler: received media map dc message', payload);
+                    this.mediaMap = payload;
                     break;
                 default:
                     this.logger.logWarn(`RTCPeer.dcHandler: unexpected dc message type ${mt}`);
@@ -221,17 +226,12 @@ export class RTCPeer extends EventEmitter {
             // to be 'sendrecv' so Firefox stops complaining.
             // In practice the transceiver is only ever going to be used to
             // receive.
-            for (const t of this.pc.getTransceivers()) {
-                if (t.receiver && t.receiver.track === ev.track) {
-                    if (t.direction !== 'sendrecv') {
-                        this.logger.logDebug('RTCPeer.onTrack: setting transceiver direction for track');
-                        t.direction = 'sendrecv';
-                    }
-                    break;
-                }
+            if (ev.transceiver.direction !== 'sendrecv') {
+                this.logger.logDebug('RTCPeer.onTrack: setting transceiver direction for track');
+                ev.transceiver.direction = 'sendrecv';
             }
         }
-        this.emit('stream', new MediaStream([ev.track]));
+        this.emit('stream', new MediaStream([ev.track]), this.mediaMap[ev.transceiver.mid]);
     }
     flushICECandidates() {
         var _a;
@@ -330,10 +330,14 @@ export class RTCPeer extends EventEmitter {
                 // properly (https://bugzilla.mozilla.org/show_bug.cgi?id=1692873).
                 // TODO: check whether track is coming from screenshare when we
                 // start supporting video.
+                let sendEncodings = this.config.simulcast && !isFirefox() ? DefaultSimulcastScreenEncodings : FallbackScreenEncodings;
+                if (opts === null || opts === void 0 ? void 0 : opts.encodings) {
+                    sendEncodings = opts.encodings;
+                }
                 this.logger.logDebug('RTCPeer.addTrack: creating new transceiver on send');
                 const trx = this.pc.addTransceiver(track, {
                     direction: 'sendonly',
-                    sendEncodings: this.config.simulcast && !isFirefox() ? DefaultSimulcastScreenEncodings : FallbackScreenEncodings,
+                    sendEncodings,
                     streams: [stream],
                 });
                 if ((opts === null || opts === void 0 ? void 0 : opts.codec) && trx.setCodecPreferences) {

--- a/lib/types/dc_msg.d.ts
+++ b/lib/types/dc_msg.d.ts
@@ -6,10 +6,17 @@ export declare enum DCMessageType {
     RoundTripTime = 5,
     Jitter = 6,
     Lock = 7,
-    Unlock = 8
+    Unlock = 8,
+    MediaMap = 9
 }
 export type DCMessageSDP = Uint8Array;
 export type DCMessageLossRate = number;
 export type DCMessageRoundTripTime = number;
 export type DCMessageJitter = number;
-export type DCMessageLock = boolean;
+export type TrackInfo = {
+    type: string;
+    sender_id: string;
+};
+export type DCMessageMediaMap = {
+    [key: string]: TrackInfo;
+};

--- a/lib/types/dc_msg.js
+++ b/lib/types/dc_msg.js
@@ -8,4 +8,5 @@ export var DCMessageType;
     DCMessageType[DCMessageType["Jitter"] = 6] = "Jitter";
     DCMessageType[DCMessageType["Lock"] = 7] = "Lock";
     DCMessageType[DCMessageType["Unlock"] = 8] = "Unlock";
+    DCMessageType[DCMessageType["MediaMap"] = 9] = "MediaMap";
 })(DCMessageType || (DCMessageType = {}));

--- a/lib/types/types.d.ts
+++ b/lib/types/types.d.ts
@@ -41,6 +41,10 @@ export type UserScreenOnOffData = {
     userID: string;
     session_id: string;
 } & BaseData;
+export type UserVideoOnOffData = {
+    userID: string;
+    session_id: string;
+} & BaseData;
 export type UserRaiseUnraiseHandData = {
     userID: string;
     session_id: string;
@@ -126,6 +130,7 @@ export type CallsConfig = {
     EnableAV1: boolean;
     GroupCallsAllowed: boolean;
     EnableDCSignaling: boolean;
+    EnableVideo: boolean;
     TranscribeAPI: TranscribeAPI;
 };
 export type Reaction = UserReactionData & {
@@ -140,9 +145,11 @@ export type SessionState = {
     user_id: string;
     unmuted: boolean;
     raised_hand: number;
+    video?: boolean;
 };
 export type UserSessionState = SessionState & {
     voice?: boolean;
+    video?: boolean;
     reaction?: Reaction;
 };
 export type CallState = {

--- a/lib/types/webrtc.d.ts
+++ b/lib/types/webrtc.d.ts
@@ -85,6 +85,13 @@ export type RTCMonitorConfig = {
     logger: Logger;
     monitorInterval: number;
 };
+export type RTPEncodingParameters = {
+    rid?: string;
+    maxBitrate: number;
+    maxFramerate: number;
+    scaleResolutionDownBy: number;
+};
 export type RTCTrackOptions = {
-    codec: RTCRtpCodecCapability;
+    codec?: RTCRtpCodecCapability;
+    encodings?: RTPEncodingParameters[];
 };

--- a/src/types/dc_msg.ts
+++ b/src/types/dc_msg.ts
@@ -7,10 +7,16 @@ export enum DCMessageType {
     Jitter,
     Lock,
     Unlock,
+    MediaMap,
 }
 
 export type DCMessageSDP = Uint8Array;
 export type DCMessageLossRate = number;
 export type DCMessageRoundTripTime = number;
 export type DCMessageJitter = number;
-export type DCMessageLock = boolean;
+export type TrackInfo = {
+    type: string;
+    sender_id: string;
+}
+export type DCMessageMediaMap = {[key: string]: TrackInfo};
+

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -59,6 +59,11 @@ export type UserScreenOnOffData = {
     session_id: string;
 } & BaseData
 
+export type UserVideoOnOffData = {
+    userID: string;
+    session_id: string;
+} & BaseData;
+
 export type UserRaiseUnraiseHandData = {
     userID: string;
     session_id: string;
@@ -179,6 +184,7 @@ export type CallsConfig = {
     EnableAV1: boolean;
     GroupCallsAllowed: boolean;
     EnableDCSignaling: boolean;
+    EnableVideo: boolean;
 
     // Admin only
     TranscribeAPI: TranscribeAPI;
@@ -198,10 +204,12 @@ export type SessionState = {
     user_id: string;
     unmuted: boolean;
     raised_hand: number;
+    video?: boolean;
 }
 
 export type UserSessionState = SessionState & {
     voice?: boolean;
+    video?: boolean;
     reaction?: Reaction;
 }
 

--- a/src/types/webrtc.ts
+++ b/src/types/webrtc.ts
@@ -101,6 +101,14 @@ export type RTCMonitorConfig = {
     monitorInterval: number;
 }
 
+export type RTPEncodingParameters = {
+    rid?: string;
+    maxBitrate: number;
+    maxFramerate: number;
+    scaleResolutionDownBy: number;
+}
+
 export type RTCTrackOptions = {
-    codec: RTCRtpCodecCapability;
+    codec?: RTCRtpCodecCapability;
+    encodings?: RTPEncodingParameters[];
 }


### PR DESCRIPTION
#### Summary

These are the required changes to our shared (web+mobile) library to enable video in Calls. The only notable change here is the addition of the `MediaMap` logic that helps us identify which track (including their type) belongs to which session. This was necessary since we can't rely on the WebRTC transport to relay server-side IDs (track IDs can change on the receiver's end).

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-63430
