### PR TITLE
Ensure lock message is sent with an open dc channel

### DIFF
--- a/lib/rtc_peer.d.ts
+++ b/lib/rtc_peer.d.ts
@@ -1,5 +1,6 @@
 import { EventEmitter } from 'events';
 import { RTCPeerConfig, RTCTrackOptions } from './types';
+export declare const signalingLockCheckIntervalMs = 50;
 export declare class RTCPeer extends EventEmitter {
     private config;
     private pc;

--- a/lib/rtc_peer.d.ts
+++ b/lib/rtc_peer.d.ts
@@ -24,6 +24,7 @@ export declare class RTCPeer extends EventEmitter {
     private onICECandidate;
     private onConnectionStateChange;
     private onICEConnectionStateChange;
+    private enqueueLockMsg;
     private grabSignalingLock;
     private onNegotiationNeeded;
     private makeOffer;

--- a/lib/rtc_peer.js
+++ b/lib/rtc_peer.js
@@ -16,7 +16,7 @@ const rtcConnFailedErr = new Error('rtc connection failed');
 const rtcConnTimeoutMsDefault = 15 * 1000;
 const pingIntervalMs = 1000;
 const signalingLockTimeoutMs = 5000;
-const signalingLockCheckIntervalMs = 50;
+export const signalingLockCheckIntervalMs = 50;
 var SimulcastLevel;
 (function (SimulcastLevel) {
     SimulcastLevel["High"] = "h";

--- a/lib/rtc_peer.js
+++ b/lib/rtc_peer.js
@@ -141,11 +141,23 @@ export class RTCPeer extends EventEmitter {
         var _a;
         this.logger.logDebug(`RTCPeer: ICE connection state change -> ${(_a = this.pc) === null || _a === void 0 ? void 0 : _a.iceConnectionState}`);
     }
+    enqueueLockMsg() {
+        setTimeout(() => {
+            if (this.dc.readyState === 'closed' || this.dc.readyState === 'closing') {
+                // Avoid requeuing if the data channel is closed or closing. This will eventually result in a timeout.
+                this.logger.logDebug('RTCPeer.enqueueLockMsg: dc closed or closing, returning');
+                return;
+            }
+            if (!this.dcNegotiated || this.dc.readyState !== 'open') {
+                this.logger.logDebug('RTCPeer.enqueueLockMsg: dc not negotiated or not open, requeing');
+                this.enqueueLockMsg();
+                return;
+            }
+            this.dc.send(encodeDCMsg(this.enc, DCMessageType.Lock));
+        }, signalingLockCheckIntervalMs);
+    }
     grabSignalingLock(timeoutMs) {
         const start = performance.now();
-        const enqueueLockMsg = () => {
-            setTimeout(() => this.dc.send(encodeDCMsg(this.enc, DCMessageType.Lock)), signalingLockCheckIntervalMs);
-        };
         return new Promise((resolve, reject) => {
             this.dcLockResponseCb = (acquired) => {
                 if (acquired) {
@@ -156,7 +168,7 @@ export class RTCPeer extends EventEmitter {
                 }
                 // If we failed to acquire the lock we wait and try again. It likely means the server side is in the
                 // process of sending us an offer (or we are).
-                enqueueLockMsg();
+                this.enqueueLockMsg();
             };
             setTimeout(() => {
                 this.dcLockResponseCb = null;
@@ -165,7 +177,7 @@ export class RTCPeer extends EventEmitter {
             // If we haven't fully negotiated the data channel or if this isn't ready yet we wait.
             if (!this.dcNegotiated || this.dc.readyState !== 'open') {
                 this.logger.logDebug('RTCPeer.grabSignalingLock: dc not negotiated or not open, requeing');
-                enqueueLockMsg();
+                this.enqueueLockMsg();
                 return;
             }
             this.dc.send(encodeDCMsg(this.enc, DCMessageType.Lock));

--- a/src/rtc_peer.test.ts
+++ b/src/rtc_peer.test.ts
@@ -140,14 +140,14 @@ describe('RTCPeer', () => {
             // Verify that no lock request was sent immediately
             expect(mockDC.send).not.toHaveBeenCalled();
 
+            // Now set data channel to ready and simulate a successful lock acquisition
+            mockDC.readyState = 'open';
+
             // Fast-forward timers to trigger the retry
             jest.advanceTimersByTime(50);
 
             // Verify that a lock request was queued
             expect(mockDC.send).toHaveBeenCalledTimes(1);
-
-            // Now set data channel to ready and simulate a successful lock acquisition
-            mockDC.readyState = 'open';
 
             // Get the callback
             const dcLockResponseCb = peer.dcLockResponseCb;
@@ -169,14 +169,14 @@ describe('RTCPeer', () => {
             // Verify that no lock request was sent immediately
             expect(mockDC.send).not.toHaveBeenCalled();
 
+            // Now set data channel to negotiated and simulate a successful lock acquisition
+            peer.dcNegotiated = true;
+
             // Fast-forward timers to trigger the retry
             jest.advanceTimersByTime(50);
 
             // Verify that a lock request was queued
             expect(mockDC.send).toHaveBeenCalledTimes(1);
-
-            // Now set data channel to negotiated and simulate a successful lock acquisition
-            peer.dcNegotiated = true;
 
             // Get the callback
             const dcLockResponseCb = peer.dcLockResponseCb;
@@ -186,6 +186,148 @@ describe('RTCPeer', () => {
 
             // Wait for the promise to resolve
             await expect(lockPromise).resolves.toBeUndefined();
+        });
+
+        it('should handle multiple failures to acquire the lock', async () => {
+            // Setup the test
+            const lockPromise = peer.grabSignalingLock(1000);
+
+            // Get the callback
+            const dcLockResponseCb = peer.dcLockResponseCb;
+
+            // Simulate multiple failed attempts to acquire the lock
+            for (let i = 0; i < 5; i++) {
+                // Simulate server response (lock not acquired)
+                dcLockResponseCb(false);
+
+                // Fast-forward timers to trigger the retry
+                jest.advanceTimersByTime(50);
+
+                // Verify that another lock request was sent
+                expect(mockDC.send).toHaveBeenCalledTimes(i + 2);
+            }
+
+            // Now simulate a successful lock acquisition
+            dcLockResponseCb(true);
+
+            // Wait for the promise to resolve
+            await expect(lockPromise).resolves.toBeUndefined();
+
+            // Verify that the callback was cleared
+            expect(peer.dcLockResponseCb).toBeNull();
+        });
+
+        it('should handle data channel not ready after first attempt', async () => {
+            // Setup the test
+            const lockPromise = peer.grabSignalingLock(1000);
+
+            // Verify that the lock request was sent
+            expect(mockDC.send).toHaveBeenCalledTimes(1);
+
+            // Get the callback
+            const dcLockResponseCb = peer.dcLockResponseCb;
+
+            // Simulate server response (lock not acquired)
+            dcLockResponseCb(false);
+
+            // Set data channel to not ready for the next attempts
+            mockDC.readyState = 'connecting';
+
+            // Try multiple times with data channel not ready
+            for (let i = 0; i < 3; i++) {
+                // Fast-forward timers to trigger the retry
+                jest.advanceTimersByTime(50);
+
+                // Verify that no additional lock request was sent (channel not ready)
+                expect(mockDC.send).toHaveBeenCalledTimes(1);
+            }
+
+            // Now set data channel back to ready
+            mockDC.readyState = 'open';
+
+            // Fast-forward timers again to trigger another retry
+            jest.advanceTimersByTime(50);
+
+            // Verify that another lock request was sent
+            expect(mockDC.send).toHaveBeenCalledTimes(2);
+
+            // Simulate successful lock acquisition
+            dcLockResponseCb(true);
+
+            // Wait for the promise to resolve
+            await expect(lockPromise).resolves.toBeUndefined();
+
+            // Verify that the callback was cleared
+            expect(peer.dcLockResponseCb).toBeNull();
+        });
+
+        it('should handle data channel getting closed during lock acquisition', async () => {
+            // Setup the test
+            const lockPromise = peer.grabSignalingLock(1000);
+
+            // Verify that the lock request was sent
+            expect(mockDC.send).toHaveBeenCalledTimes(1);
+
+            // Get the callback
+            const dcLockResponseCb = peer.dcLockResponseCb;
+
+            // Simulate server response (lock not acquired)
+            dcLockResponseCb(false);
+
+            // Set data channel to closed state
+            mockDC.readyState = 'closed';
+
+            // Fast-forward timers to trigger the retry
+            jest.advanceTimersByTime(50);
+
+            // Verify that no additional lock request was sent (channel closed)
+            expect(mockDC.send).toHaveBeenCalledTimes(1);
+
+            // Fast-forward timers again to check if it continues trying
+            jest.advanceTimersByTime(50);
+
+            // Verify that no more attempts were made with closed channel
+            expect(mockDC.send).toHaveBeenCalledTimes(1);
+
+            // Fast-forward to trigger timeout
+            jest.advanceTimersByTime(1000);
+
+            // Wait for the promise to reject due to timeout
+            await expect(lockPromise).rejects.toThrow('timed out waiting for lock');
+
+            // Verify that the callback was cleared
+            expect(peer.dcLockResponseCb).toBeNull();
+        });
+
+        it.only('should handle data channel that never opens and transitions to closed', async () => {
+            // Set data channel to connecting state initially
+            mockDC.readyState = 'connecting';
+
+            // Setup the test
+            const lockPromise = peer.grabSignalingLock(1000);
+
+            // Verify that no lock request was sent immediately (channel not ready)
+            expect(mockDC.send).not.toHaveBeenCalled();
+
+            // Transition data channel directly to closed state
+            mockDC.readyState = 'closed';
+
+            // Fast-forward timers multiple times to check if it continues trying
+            for (let i = 0; i < 5; i++) {
+                jest.advanceTimersByTime(50);
+
+                // Verify that no lock requests were sent (channel closed)
+                expect(mockDC.send).not.toHaveBeenCalled();
+            }
+
+            // Fast-forward to trigger timeout
+            jest.advanceTimersByTime(1000);
+
+            // Wait for the promise to reject due to timeout
+            await expect(lockPromise).rejects.toThrow('timed out waiting for lock');
+
+            // Verify that the callback was cleared
+            expect(peer.dcLockResponseCb).toBeNull();
         });
     });
 });

--- a/src/rtc_peer.ts
+++ b/src/rtc_peer.ts
@@ -164,12 +164,27 @@ export class RTCPeer extends EventEmitter {
         this.logger.logDebug(`RTCPeer: ICE connection state change -> ${this.pc?.iceConnectionState}`);
     }
 
+    private enqueueLockMsg() {
+        setTimeout(() => {
+            if (this.dc.readyState === 'closed' || this.dc.readyState === 'closing') {
+                // Avoid requeuing if the data channel is closed or closing. This will eventually result in a timeout.
+                this.logger.logDebug('RTCPeer.enqueueLockMsg: dc closed or closing, returning');
+                return;
+            }
+
+            if (!this.dcNegotiated || this.dc.readyState !== 'open') {
+                this.logger.logDebug('RTCPeer.enqueueLockMsg: dc not negotiated or not open, requeing');
+
+                this.enqueueLockMsg();
+                return;
+            }
+
+            this.dc.send(encodeDCMsg(this.enc, DCMessageType.Lock));
+        }, signalingLockCheckIntervalMs);
+    }
+
     private grabSignalingLock(timeoutMs: number) {
         const start = performance.now();
-
-        const enqueueLockMsg = () => {
-            setTimeout(() => this.dc.send(encodeDCMsg(this.enc, DCMessageType.Lock)), signalingLockCheckIntervalMs);
-        };
 
         return new Promise<void>((resolve, reject) => {
             this.dcLockResponseCb = (acquired) => {
@@ -182,7 +197,7 @@ export class RTCPeer extends EventEmitter {
 
                 // If we failed to acquire the lock we wait and try again. It likely means the server side is in the
                 // process of sending us an offer (or we are).
-                enqueueLockMsg();
+                this.enqueueLockMsg();
             };
 
             setTimeout(() => {
@@ -194,7 +209,7 @@ export class RTCPeer extends EventEmitter {
             if (!this.dcNegotiated || this.dc.readyState !== 'open') {
                 this.logger.logDebug('RTCPeer.grabSignalingLock: dc not negotiated or not open, requeing');
 
-                enqueueLockMsg();
+                this.enqueueLockMsg();
                 return;
             }
 

--- a/src/rtc_peer.ts
+++ b/src/rtc_peer.ts
@@ -12,7 +12,7 @@ const rtcConnFailedErr = new Error('rtc connection failed');
 const rtcConnTimeoutMsDefault = 15 * 1000;
 const pingIntervalMs = 1000;
 const signalingLockTimeoutMs = 5000;
-const signalingLockCheckIntervalMs = 50;
+export const signalingLockCheckIntervalMs = 50;
 
 enum SimulcastLevel {
     High = 'h',


### PR DESCRIPTION
#### Summary

When testing this on Community, I noticed we were trying to send the lock message on a DC channel in the "connecting" state, but it would fail, ultimately causing a timeout. This is probably because the RTCD side is somehow slower in achieving connectivity (to note, this didn't happen in our calls test server :man_shrugging: ). 

Regardless, there was a bug because we should continue to queue and re-attempt up to the timeout rather than queue only once, plus ensure we are only sending on an open channel.

