### PR TITLE
[MM-63776] Dynamic video encodings

### DIFF
--- a/lib/rtc_peer.d.ts
+++ b/lib/rtc_peer.d.ts
@@ -7,7 +7,7 @@ export declare class RTCPeer extends EventEmitter {
     private dc;
     private dcNegotiated;
     private dcLockResponseCb;
-    private readonly senders;
+    private readonly trackCtxs;
     private readonly logger;
     private enc;
     private dec;
@@ -22,6 +22,8 @@ export declare class RTCPeer extends EventEmitter {
     codecSupportMap: DCMessageCodecSupportMap;
     constructor(config: RTCPeerConfig);
     private dcHandler;
+    private switchCodecForTrack;
+    private handleCodecSupportUpdate;
     private initPingHandler;
     getRTT(): number;
     private onICECandidate;
@@ -31,12 +33,14 @@ export declare class RTCPeer extends EventEmitter {
     private grabSignalingLock;
     private onNegotiationNeeded;
     private makeOffer;
+    private unlockSignalingLock;
     private onTrack;
     private flushICECandidates;
     signal(data: string): Promise<void>;
+    private addTrackNoLock;
     addTrack(track: MediaStreamTrack, stream: MediaStream, opts?: RTCTrackOptions): Promise<void>;
     addStream(stream: MediaStream, opts?: RTCTrackOptions[]): Promise<void>;
-    replaceTrack(oldTrackID: string, newTrack: MediaStreamTrack | null): void;
+    replaceTrack(oldTrackID: string, newTrack: MediaStreamTrack | null): Promise<void>;
     removeTrack(trackID: string): Promise<void>;
     getStats(): Promise<RTCStatsReport>;
     handleMetrics(lossRate: number, jitter: number): void;

--- a/lib/rtc_peer.d.ts
+++ b/lib/rtc_peer.d.ts
@@ -1,5 +1,5 @@
 import { EventEmitter } from 'events';
-import { RTCPeerConfig, RTCTrackOptions } from './types';
+import { RTCPeerConfig, RTCTrackOptions, DCMessageCodecSupportMap } from './types';
 export declare const signalingLockCheckIntervalMs = 50;
 export declare class RTCPeer extends EventEmitter {
     private config;
@@ -19,6 +19,7 @@ export declare class RTCPeer extends EventEmitter {
     private candidates;
     connected: boolean;
     private mediaMap;
+    codecSupportMap: DCMessageCodecSupportMap;
     constructor(config: RTCPeerConfig);
     private dcHandler;
     private initPingHandler;

--- a/lib/rtc_peer.js
+++ b/lib/rtc_peer.js
@@ -9,7 +9,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 import { EventEmitter } from 'events';
 import { Encoder, Decoder } from '@msgpack/msgpack';
-import { DCMessageType } from './types';
+import { DCMessageType, DCMessageCodecSupportMapDefault, } from './types';
 import { encodeDCMsg, decodeDCMsg } from './dc_msg';
 import { isFirefox } from './utils';
 const rtcConnFailedErr = new Error('rtc connection failed');
@@ -40,6 +40,7 @@ export class RTCPeer extends EventEmitter {
         this.makingOffer = false;
         this.candidates = [];
         this.mediaMap = {};
+        this.codecSupportMap = DCMessageCodecSupportMapDefault;
         this.config = config;
         this.logger = config.logger;
         // We keep a map of track IDs -> RTP sender so that we can easily
@@ -93,6 +94,10 @@ export class RTCPeer extends EventEmitter {
                 case DCMessageType.MediaMap:
                     this.logger.logDebug('RTCPeer.dcHandler: received media map dc message', payload);
                     this.mediaMap = payload;
+                    break;
+                case DCMessageType.CodecSupportMap:
+                    this.logger.logDebug('RTCPeer.dcHandler: received codec support map dc message', payload);
+                    this.codecSupportMap = payload;
                     break;
                 default:
                     this.logger.logWarn(`RTCPeer.dcHandler: unexpected dc message type ${mt}`);

--- a/lib/rtc_peer.js
+++ b/lib/rtc_peer.js
@@ -9,9 +9,9 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 import { EventEmitter } from 'events';
 import { Encoder, Decoder } from '@msgpack/msgpack';
-import { DCMessageType, DCMessageCodecSupportMapDefault, } from './types';
+import { DCMessageType, DCMessageCodecSupportMapDefault, CodecSupportLevel, CodecMimeType, } from './types';
 import { encodeDCMsg, decodeDCMsg } from './dc_msg';
-import { isFirefox } from './utils';
+import { isFirefox, sleep } from './utils';
 const rtcConnFailedErr = new Error('rtc connection failed');
 const rtcConnTimeoutMsDefault = 15 * 1000;
 const pingIntervalMs = 1000;
@@ -43,11 +43,13 @@ export class RTCPeer extends EventEmitter {
         this.codecSupportMap = DCMessageCodecSupportMapDefault;
         this.config = config;
         this.logger = config.logger;
-        // We keep a map of track IDs -> RTP sender so that we can easily
-        // replace tracks when muting/unmuting.
-        this.senders = {};
+        // We keep a map of track IDs -> TrackContext in order to dynamically switch
+        // encoders as receivers codec support varies in a call.
+        this.trackCtxs = {};
         this.pc = new RTCPeerConnection(config);
-        this.pc.onnegotiationneeded = () => this.onNegotiationNeeded();
+        // As of MM-63776 we don't set pc.onnegotiationneeded since
+        // it makes it much harder to ensure negotiations happen under signaling lock.
+        // This means that this.onNegotiationNeeded() must be called manually (see addTrack for an example).
         this.pc.onicecandidate = (ev) => this.onICECandidate(ev);
         this.pc.oniceconnectionstatechange = () => this.onICEConnectionStateChange();
         this.pc.onconnectionstatechange = () => this.onConnectionStateChange();
@@ -70,6 +72,9 @@ export class RTCPeer extends EventEmitter {
         this.dc.onmessage = (ev) => this.dcHandler(ev);
         this.pingIntervalID = this.initPingHandler();
         this.logger.logDebug('RTCPeer: created new client', JSON.stringify(config));
+        this.onNegotiationNeeded().catch((err) => {
+            this.logger.logErr('RTCPeer: onNegotiationNeeded failed', err);
+        });
     }
     dcHandler(ev) {
         var _a;
@@ -84,7 +89,8 @@ export class RTCPeer extends EventEmitter {
                 case DCMessageType.SDP:
                     this.logger.logDebug('RTCPeer.dcHandler: received sdp dc message');
                     this.signal(payload).catch((err) => {
-                        this.logger.logErr('RTCPeer.dcHandler: failed to signal sdp', err);
+                        this.logger.logErr('RTCPeer.dcHandler: failed to signal sdp, unlocking', err);
+                        return this.unlockSignalingLock();
                     });
                     break;
                 case DCMessageType.Lock:
@@ -98,6 +104,18 @@ export class RTCPeer extends EventEmitter {
                 case DCMessageType.CodecSupportMap:
                     this.logger.logDebug('RTCPeer.dcHandler: received codec support map dc message', payload);
                     this.codecSupportMap = payload;
+                    this.logger.logDebug('RTCPeer.dcHandler: codec support map: grabbing signaling lock');
+                    // We don't want to block this function since it's paramount to handle negotiation and locking responses.
+                    this.grabSignalingLock(signalingLockTimeoutMs).then(() => this.handleCodecSupportUpdate(this.codecSupportMap)).then((needsNegotiation) => {
+                        this.logger.logDebug('RTCPeer.dcHandler: codec support update handled', needsNegotiation);
+                        if (!needsNegotiation) {
+                            this.logger.logDebug('RTCPeer.handleCodecSupportUpdate: no negotiation needed, unlocking');
+                            this.unlockSignalingLock();
+                        }
+                    }).catch((err) => {
+                        this.logger.logErr('RTCPeer.dcHandler: failed to handle codec support update, unlocking', err);
+                        this.unlockSignalingLock();
+                    });
                     break;
                 default:
                     this.logger.logWarn(`RTCPeer.dcHandler: unexpected dc message type ${mt}`);
@@ -106,6 +124,99 @@ export class RTCPeer extends EventEmitter {
         catch (err) {
             this.logger.logErr('failed to decode dc message', err);
         }
+    }
+    switchCodecForTrack(tctx, targetCodec) {
+        return __awaiter(this, void 0, void 0, function* () {
+            var _a;
+            // First, we stop sending the track with the current codec.
+            // This is to ensure we are only sending one encoding at any given time.
+            // Replacing the track this way also allows us to quickly start sending again
+            // if support changes during the call (e.g. the only unsupported client leaves).
+            yield tctx.sender.replaceTrack(null);
+            // Check if we already have a sender with the target codec that can be reused. This avoids having to add a new track (and transceiver)
+            // every time we need to switch codecs. Once we switched once we should have both VP8 and AV1 senders available.
+            const existingSender = (_a = this.pc) === null || _a === void 0 ? void 0 : _a.getSenders().find((s) => {
+                var _a;
+                const params = s.getParameters();
+                return s.track === null && ((_a = params.codecs) === null || _a === void 0 ? void 0 : _a.length) > 0 && params.codecs[0].mimeType === targetCodec.mimeType;
+            });
+            if (existingSender) {
+                this.logger.logDebug(`RTCPeer.switchCodecForTrack: ${targetCodec.mimeType} sender already exists, replacing track`, existingSender, tctx);
+                yield existingSender.replaceTrack(tctx.track);
+                this.trackCtxs[tctx.track.id] = Object.assign(Object.assign({}, tctx), { sender: existingSender });
+            }
+            else {
+                // Prepare options with the target codec
+                const opts = Object.assign(Object.assign({}, tctx.opts), { 
+                    // It's important we force the codec here, otherwise the server side may just answer
+                    // saying it's okay what we are sending already :)
+                    codecs: [targetCodec] });
+                this.logger.logDebug(`RTCPeer.switchCodecForTrack: ${targetCodec.mimeType} sender does not exist, adding new track`, opts, tctx);
+                // We are under signaling lock here, so must call the non-locked method for adding a new track.
+                yield this.addTrackNoLock(tctx.track, tctx.stream, opts);
+            }
+        });
+    }
+    // handleCodecSupportUpdate is called when the codec support map is received from the server.
+    // It returns a boolean indicating whether renegotiation is needed, in which case we shouldn't
+    // unlock the signaling lock.
+    handleCodecSupportUpdate(supportMap) {
+        return __awaiter(this, void 0, void 0, function* () {
+            // We'll keep this simple as we only need to handle VP8<->AV1 transitions for the time being.
+            // A more generic solution can be implemented later if needed.
+            var _a, _b;
+            // First we to check whether the client can send AV1, otherwise there's no point continuing.
+            const av1Codec = yield RTCPeer.getVideoCodec(CodecMimeType.AV1);
+            if (!av1Codec) {
+                this.logger.logDebug('RTCPeer.handleCodecSupportUpdate: client does not support AV1 codec, returning');
+                return false;
+            }
+            const vp8Codec = yield RTCPeer.getVideoCodec(CodecMimeType.VP8);
+            if (!vp8Codec) {
+                // Realistically, this should never happen.
+                this.logger.logErr('RTCPeer.handleCodecSupportUpdate: client does not support VP8 codec, returning');
+                return false;
+            }
+            // Second, we check AV1 support level of the call. Partial or None levels are treated the same as we don't want to send
+            // multiple encodings at the same time. This means we need full support to send an AV1-encoded track.
+            const av1CallSupport = supportMap[CodecMimeType.AV1] === CodecSupportLevel.Full;
+            // Now we check whether we need to make any changes to our encodings for outgoing tracks (senders).
+            // If av1CallSupport is true, we need to ensure that we are sending AV1 (if we are sending any video tracks that is)
+            // Else, if av1CallSupport is false, we need to ensure we are sending video tracks using VP8 and switch codec where necessary.
+            const targetCodec = av1CallSupport ? av1Codec : vp8Codec;
+            let needsNegotiation = false;
+            for (const tctx of Object.values(this.trackCtxs)) {
+                if (((_a = tctx.sender.track) === null || _a === void 0 ? void 0 : _a.kind) !== 'video') {
+                    // Skip non-video tracks.
+                    continue;
+                }
+                this.logger.logDebug(`RTCPeer.handleCodecSupportUpdate: av1CallSupport=${av1CallSupport} checking video sender`, tctx);
+                const params = tctx.sender.getParameters();
+                const currentCodec = params.codecs[0];
+                // Only switch if we're not already sending the track using the target codec.
+                if (currentCodec.mimeType !== targetCodec.mimeType) {
+                    this.logger.logDebug(`RTCPeer.handleCodecSupportUpdate: ${targetCodec.mimeType} codec not used for video sender, need to switch encoder to ${targetCodec.mimeType}`, av1CallSupport, currentCodec, tctx);
+                    // eslint-disable-next-line no-await-in-loop
+                    yield this.switchCodecForTrack(tctx, targetCodec);
+                    needsNegotiation = true;
+                }
+            }
+            const existingTransceiver = (_b = this.pc) === null || _b === void 0 ? void 0 : _b.getTransceivers().find((trx) => {
+                var _a;
+                if (!trx.receiver) {
+                    return false;
+                }
+                return trx.receiver.track && ((_a = this.mediaMap[trx.mid]) === null || _a === void 0 ? void 0 : _a.mime_type) === targetCodec.mimeType;
+            });
+            if (existingTransceiver) {
+                this.logger.logDebug(`RTCPeer.handleCodecSupportUpdate: ${targetCodec.mimeType} receiver already exists, need to emit track`, existingTransceiver, existingTransceiver.receiver.track);
+                this.emit('stream', new MediaStream([existingTransceiver.receiver.track]), this.mediaMap[existingTransceiver.mid]);
+            }
+            if (needsNegotiation) {
+                yield this.onNegotiationNeeded();
+            }
+            return needsNegotiation;
+        });
     }
     initPingHandler() {
         return setInterval(() => {
@@ -169,28 +280,42 @@ export class RTCPeer extends EventEmitter {
     grabSignalingLock(timeoutMs) {
         const start = performance.now();
         return new Promise((resolve, reject) => {
-            this.dcLockResponseCb = (acquired) => {
-                if (acquired) {
-                    this.logger.logDebug(`RTCPeer.grabSignalingLock: lock acquired in ${Math.round(performance.now() - start)}ms`);
+            // The attemptLock wrapper is needed since Promise executor should be synchronous.
+            const attemptLock = () => __awaiter(this, void 0, void 0, function* () {
+                // This covers the case of "concurrent" (interleaved in practice) attempts to lock
+                // which would otherwise result in this.dcLockResponseCb getting overwritten.
+                // Waiting ensures lock attempts are all done fully serially.
+                while (this.dcLockResponseCb) {
+                    if ((performance.now() - start) > timeoutMs) {
+                        throw new Error('timed out waiting for lock');
+                    }
+                    this.logger.logDebug(`RTCPeer.grabSignalingLock: already waiting for lock, retrying in ${signalingLockCheckIntervalMs}ms`);
+                    // eslint-disable-next-line no-await-in-loop
+                    yield sleep(signalingLockCheckIntervalMs);
+                }
+                this.dcLockResponseCb = (acquired) => {
+                    if (acquired) {
+                        this.logger.logDebug(`RTCPeer.grabSignalingLock: lock acquired in ${Math.round(performance.now() - start)}ms`);
+                        this.dcLockResponseCb = null;
+                        resolve();
+                    }
+                    else {
+                        this.enqueueLockMsg();
+                    }
+                };
+                setTimeout(() => {
                     this.dcLockResponseCb = null;
-                    resolve();
+                    reject(new Error('timed out waiting for lock'));
+                }, timeoutMs);
+                if (!this.dcNegotiated || this.dc.readyState !== 'open') {
+                    this.logger.logDebug('RTCPeer.grabSignalingLock: dc not negotiated or not open, requeing');
+                    this.enqueueLockMsg();
                     return;
                 }
-                // If we failed to acquire the lock we wait and try again. It likely means the server side is in the
-                // process of sending us an offer (or we are).
-                this.enqueueLockMsg();
-            };
-            setTimeout(() => {
-                this.dcLockResponseCb = null;
-                reject(new Error('timed out waiting for lock'));
-            }, timeoutMs);
-            // If we haven't fully negotiated the data channel or if this isn't ready yet we wait.
-            if (!this.dcNegotiated || this.dc.readyState !== 'open') {
-                this.logger.logDebug('RTCPeer.grabSignalingLock: dc not negotiated or not open, requeing');
-                this.enqueueLockMsg();
-                return;
-            }
-            this.dc.send(encodeDCMsg(this.enc, DCMessageType.Lock));
+                this.dc.send(encodeDCMsg(this.enc, DCMessageType.Lock));
+            });
+            // Start the lock attempt
+            attemptLock().catch((err) => reject(err));
         });
     }
     onNegotiationNeeded() {
@@ -227,15 +352,22 @@ export class RTCPeer extends EventEmitter {
             }
             catch (err) {
                 this.emit('error', err);
-                if (this.dcNegotiated && this.dc.readyState === 'open') {
-                    this.logger.logErr('RTCPeer.makeOffer: unlocking on error');
-                    this.dc.send(encodeDCMsg(this.enc, DCMessageType.Unlock));
-                }
+                this.logger.logErr('RTCPeer.makeOffer: failed to create offer, unlocking', err);
+                this.unlockSignalingLock();
             }
             finally {
                 this.makingOffer = false;
             }
         });
+    }
+    unlockSignalingLock() {
+        if (this.dcNegotiated && this.dc.readyState === 'open') {
+            this.logger.logDebug('RTCPeer.unlockSignalingLock: unlocking');
+            this.dc.send(encodeDCMsg(this.enc, DCMessageType.Unlock));
+        }
+        else {
+            this.logger.logWarn('RTCPeer.unlockSignalingLock: dc not negotiated or not open');
+        }
     }
     onTrack(ev) {
         this.emit('stream', new MediaStream([ev.track]), this.mediaMap[ev.transceiver.mid]);
@@ -305,15 +437,15 @@ export class RTCPeer extends EventEmitter {
                     if (this.candidates.length > 0) {
                         this.flushICECandidates();
                     }
-                    if (!this.dcNegotiated) {
-                        this.dcNegotiated = true;
-                    }
-                    else if (this.dc.readyState === 'open') {
-                        this.logger.logDebug('RTCPeer.signal: unlocking signaling lock');
-                        this.dc.send(encodeDCMsg(this.enc, DCMessageType.Unlock));
+                    if (this.dcNegotiated) {
+                        if (this.dc.readyState !== 'open') {
+                            this.logger.logWarn('RTCPeer.signal: dc not open upon receiving answer');
+                        }
+                        this.logger.logDebug('RTCPeer.signal: handled remote answer, unlocking');
+                        yield this.unlockSignalingLock();
                     }
                     else {
-                        this.logger.logWarn('RTCPeer.signal: dc not open upon receiving answer');
+                        this.dcNegotiated = true;
                     }
                     break;
                 default:
@@ -321,15 +453,11 @@ export class RTCPeer extends EventEmitter {
             }
         });
     }
-    addTrack(track, stream, opts) {
+    addTrackNoLock(track, stream, opts) {
         return __awaiter(this, void 0, void 0, function* () {
             if (!this.pc) {
                 throw new Error('peer has been destroyed');
             }
-            // We need to acquire a signaling lock before we can proceed with adding the track.
-            yield this.grabSignalingLock(signalingLockTimeoutMs);
-            // Lock acquired, we can now proceed.
-            this.logger.logDebug('RTCPeer.addTrack: signaling locked acquired');
             let sender;
             if (track.kind === 'video') {
                 // Simulcast
@@ -347,19 +475,49 @@ export class RTCPeer extends EventEmitter {
                     sendEncodings,
                     streams: [stream],
                 });
-                if ((opts === null || opts === void 0 ? void 0 : opts.codec) && trx.setCodecPreferences) {
-                    this.logger.logDebug('setting video codec preference', opts.codec);
-                    trx.setCodecPreferences([opts.codec]);
+                if (trx.setCodecPreferences) {
+                    const vp8Codec = yield RTCPeer.getVideoCodec(CodecMimeType.VP8);
+                    if (!vp8Codec) {
+                        throw new Error('VP8 codec not found');
+                    }
+                    const codecs = [vp8Codec];
+                    const av1Codec = yield RTCPeer.getVideoCodec(CodecMimeType.AV1);
+                    if (av1Codec) {
+                        codecs.push(av1Codec);
+                    }
+                    if (av1Codec && this.config.enableAV1 && this.codecSupportMap[CodecMimeType.AV1] === CodecSupportLevel.Full) {
+                        this.logger.logDebug('RTCPeer.addTrack: AV1 enabled and full support in call, setting AV1 codec as preferred');
+                        codecs.reverse();
+                    }
+                    this.logger.logDebug('RTCPeer.addTrack: setting video codec preference', codecs);
+                    trx.setCodecPreferences(codecs);
                 }
                 sender = trx.sender;
             }
             else {
+                // TODO: MM-63811, use transceiver API
                 sender = yield this.pc.addTrack(track, stream);
             }
-            if (!this.senders[track.id]) {
-                this.senders[track.id] = [];
+            this.trackCtxs[track.id] = {
+                sender,
+                stream,
+                opts,
+                track,
+            };
+        });
+    }
+    addTrack(track, stream, opts) {
+        return __awaiter(this, void 0, void 0, function* () {
+            if (!this.pc) {
+                throw new Error('peer has been destroyed');
             }
-            this.senders[track.id].push(sender);
+            this.logger.logDebug('RTCPeer.addTrack: grabbing signaling lock');
+            // We need to acquire a signaling lock before we can proceed with adding the track.
+            yield this.grabSignalingLock(signalingLockTimeoutMs);
+            // Lock acquired, we can now proceed.
+            this.logger.logDebug('RTCPeer.addTrack: signaling locked acquired');
+            yield this.addTrackNoLock(track, stream, opts);
+            yield this.onNegotiationNeeded();
         });
     }
     addStream(stream, opts) {
@@ -373,39 +531,40 @@ export class RTCPeer extends EventEmitter {
         });
     }
     replaceTrack(oldTrackID, newTrack) {
-        if (!this.pc) {
-            throw new Error('peer has been destroyed');
-        }
-        // Since we expect replaceTrack not to cause a re-negotiation, locking is not required.
-        const senders = this.senders[oldTrackID];
-        if (!senders) {
-            throw new Error('senders for track not found');
-        }
-        if (newTrack && newTrack.id !== oldTrackID) {
-            delete this.senders[oldTrackID];
-            this.senders[newTrack.id] = senders;
-        }
-        for (const sender of senders) {
-            sender.replaceTrack(newTrack);
-        }
+        return __awaiter(this, void 0, void 0, function* () {
+            if (!this.pc) {
+                throw new Error('peer has been destroyed');
+            }
+            // Since we expect replaceTrack not to cause a re-negotiation, locking is not required.
+            const ctx = this.trackCtxs[oldTrackID];
+            if (!ctx) {
+                throw new Error('ctx for track not found');
+            }
+            if (newTrack && newTrack.id !== oldTrackID) {
+                this.trackCtxs[newTrack.id] = Object.assign(Object.assign({}, this.trackCtxs[oldTrackID]), { track: newTrack });
+                delete this.trackCtxs[oldTrackID];
+            }
+            yield ctx.sender.replaceTrack(newTrack);
+        });
     }
     removeTrack(trackID) {
         return __awaiter(this, void 0, void 0, function* () {
             if (!this.pc) {
                 throw new Error('peer has been destroyed');
             }
+            this.logger.logDebug('RTCPeer.removeTrack: grabbing signaling lock');
             // We need to acquire the signaling lock before we can proceed with removing the track.
             yield this.grabSignalingLock(signalingLockTimeoutMs);
             // Lock acquired, we can now proceed.
             this.logger.logDebug('RTCPeer.removeTrack: signaling locked acquired');
-            const senders = this.senders[trackID];
-            if (!senders) {
-                throw new Error('senders for track not found');
+            const ctx = this.trackCtxs[trackID];
+            if (!ctx) {
+                throw new Error('ctx for track not found');
             }
-            for (const sender of senders) {
-                this.pc.removeTrack(sender);
-            }
-            delete this.senders[trackID];
+            // TODO: MM-63811, use transceiver API
+            yield this.pc.removeTrack(ctx.sender);
+            delete this.trackCtxs[trackID];
+            yield this.onNegotiationNeeded();
         });
     }
     getStats() {
@@ -456,7 +615,6 @@ export class RTCPeer extends EventEmitter {
         this.removeAllListeners('offer');
         this.removeAllListeners('answer');
         this.removeAllListeners('stream');
-        this.pc.onnegotiationneeded = null;
         this.pc.onicecandidate = null;
         this.pc.oniceconnectionstatechange = null;
         this.pc.onconnectionstatechange = null;

--- a/lib/types/dc_msg.d.ts
+++ b/lib/types/dc_msg.d.ts
@@ -7,7 +7,8 @@ export declare enum DCMessageType {
     Jitter = 6,
     Lock = 7,
     Unlock = 8,
-    MediaMap = 9
+    MediaMap = 9,
+    CodecSupportMap = 10
 }
 export type DCMessageSDP = Uint8Array;
 export type DCMessageLossRate = number;
@@ -19,4 +20,18 @@ export type TrackInfo = {
 };
 export type DCMessageMediaMap = {
     [key: string]: TrackInfo;
+};
+export declare enum CodecSupportLevel {
+    None = 0,
+    Partial = 1,
+    Full = 2
+}
+export declare enum CodecMimeType {
+    AV1 = "video/AV1"
+}
+export type DCMessageCodecSupportMap = {
+    [key in CodecMimeType]: CodecSupportLevel;
+};
+export declare const DCMessageCodecSupportMapDefault: {
+    "video/AV1": CodecSupportLevel;
 };

--- a/lib/types/dc_msg.d.ts
+++ b/lib/types/dc_msg.d.ts
@@ -17,6 +17,7 @@ export type DCMessageJitter = number;
 export type TrackInfo = {
     type: string;
     sender_id: string;
+    mime_type: CodecMimeType;
 };
 export type DCMessageMediaMap = {
     [key: string]: TrackInfo;
@@ -27,11 +28,13 @@ export declare enum CodecSupportLevel {
     Full = 2
 }
 export declare enum CodecMimeType {
-    AV1 = "video/AV1"
+    AV1 = "video/AV1",
+    VP8 = "video/VP8"
 }
 export type DCMessageCodecSupportMap = {
     [key in CodecMimeType]: CodecSupportLevel;
 };
 export declare const DCMessageCodecSupportMapDefault: {
     "video/AV1": CodecSupportLevel;
+    "video/VP8": CodecSupportLevel;
 };

--- a/lib/types/dc_msg.js
+++ b/lib/types/dc_msg.js
@@ -20,7 +20,9 @@ export var CodecSupportLevel;
 export var CodecMimeType;
 (function (CodecMimeType) {
     CodecMimeType["AV1"] = "video/AV1";
+    CodecMimeType["VP8"] = "video/VP8";
 })(CodecMimeType || (CodecMimeType = {}));
 export const DCMessageCodecSupportMapDefault = {
     [CodecMimeType.AV1]: CodecSupportLevel.None,
+    [CodecMimeType.VP8]: CodecSupportLevel.Full,
 };

--- a/lib/types/dc_msg.js
+++ b/lib/types/dc_msg.js
@@ -9,4 +9,18 @@ export var DCMessageType;
     DCMessageType[DCMessageType["Lock"] = 7] = "Lock";
     DCMessageType[DCMessageType["Unlock"] = 8] = "Unlock";
     DCMessageType[DCMessageType["MediaMap"] = 9] = "MediaMap";
+    DCMessageType[DCMessageType["CodecSupportMap"] = 10] = "CodecSupportMap";
 })(DCMessageType || (DCMessageType = {}));
+export var CodecSupportLevel;
+(function (CodecSupportLevel) {
+    CodecSupportLevel[CodecSupportLevel["None"] = 0] = "None";
+    CodecSupportLevel[CodecSupportLevel["Partial"] = 1] = "Partial";
+    CodecSupportLevel[CodecSupportLevel["Full"] = 2] = "Full";
+})(CodecSupportLevel || (CodecSupportLevel = {}));
+export var CodecMimeType;
+(function (CodecMimeType) {
+    CodecMimeType["AV1"] = "video/AV1";
+})(CodecMimeType || (CodecMimeType = {}));
+export const DCMessageCodecSupportMapDefault = {
+    [CodecMimeType.AV1]: CodecSupportLevel.None,
+};

--- a/lib/types/webrtc.d.ts
+++ b/lib/types/webrtc.d.ts
@@ -6,6 +6,7 @@ export type RTCPeerConfig = {
     simulcast?: boolean;
     connTimeoutMs?: number;
     dcSignaling?: boolean;
+    enableAV1?: boolean;
 };
 export type SSRCStats = {
     [key: number]: {
@@ -92,6 +93,5 @@ export type RTPEncodingParameters = {
     scaleResolutionDownBy: number;
 };
 export type RTCTrackOptions = {
-    codec?: RTCRtpCodecCapability;
     encodings?: RTPEncodingParameters[];
 };

--- a/lib/utils.d.ts
+++ b/lib/utils.d.ts
@@ -1,2 +1,3 @@
 export declare function isFirefox(): boolean;
 export declare function getFirefoxVersion(): number;
+export declare function sleep(ms: number): Promise<unknown>;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -8,3 +8,6 @@ export function getFirefoxVersion() {
     }
     return parseInt(match[1], 10);
 }
+export function sleep(ms) {
+    return new Promise(resolve => setTimeout(resolve, ms));
+}

--- a/src/dc_msg.test.ts
+++ b/src/dc_msg.test.ts
@@ -1,7 +1,7 @@
 import {expect} from '@jest/globals';
 import {Encoder, Decoder} from '@msgpack/msgpack';
 
-import {DCMessageType} from './types';
+import {DCMessageType, CodecSupportLevel} from './types';
 import {encodeDCMsg, decodeDCMsg} from './dc_msg';
 
 describe('dcMsg', () => {
@@ -61,5 +61,20 @@ describe('dcMsg', () => {
         const {mt, payload} = decodeDCMsg(dec, unlockMsg);
         expect(mt).toEqual(DCMessageType.Unlock);
         expect(payload).toBeUndefined();
+    });
+
+    it('codecSupportMap', () => {
+        const codecSupportMap = {
+            'video/vp8': CodecSupportLevel.Full,
+            'video/vp9': CodecSupportLevel.Partial,
+            'video/h264': CodecSupportLevel.Full,
+            'video/av1': CodecSupportLevel.None,
+            'audio/opus': CodecSupportLevel.Full,
+        };
+        const codecSupportMapMsg = encodeDCMsg(enc, DCMessageType.CodecSupportMap, codecSupportMap);
+
+        const {mt, payload} = decodeDCMsg(dec, codecSupportMapMsg);
+        expect(mt).toEqual(DCMessageType.CodecSupportMap);
+        expect(payload).toEqual(codecSupportMap);
     });
 });

--- a/src/rtc_peer.test.ts
+++ b/src/rtc_peer.test.ts
@@ -1,5 +1,9 @@
 import {expect, describe, it, beforeEach, afterEach} from '@jest/globals';
 
+import {
+    DCMessageType,
+} from './types';
+
 import {RTCPeer, signalingLockCheckIntervalMs} from './rtc_peer';
 import * as dcMsg from './dc_msg';
 
@@ -324,6 +328,113 @@ describe('RTCPeer', () => {
 
             // Verify that the callback was cleared
             expect(peer.dcLockResponseCb).toBeNull();
+        });
+
+        it('should handle multiple concurrent lock attempts', async () => {
+            // Start first lock attempt
+            const firstLockPromise = peer.grabSignalingLock(1000);
+
+            // Verify that the first lock request was sent
+            expect(mockDC.send).toHaveBeenCalledTimes(1);
+
+            // Get the callback for the first attempt
+            const firstLockResponseCb = peer.dcLockResponseCb;
+            expect(firstLockResponseCb).toBeTruthy();
+
+            // Start second lock attempt before first one completes
+            const secondLockPromise = peer.grabSignalingLock(1000);
+
+            // Verify that no additional lock request was sent yet (first one still pending)
+            expect(mockDC.send).toHaveBeenCalledTimes(1);
+
+            // The callback should still be the first one
+            expect(peer.dcLockResponseCb).toBe(firstLockResponseCb);
+
+            // Resolve the first lock attempt
+            firstLockResponseCb(true);
+
+            // Wait for the first promise to resolve
+            await firstLockPromise;
+
+            // After first lock resolves, the second lock should now be attempted
+            // Fast-forward timers to allow the second lock to be processed
+            jest.advanceTimersByTime(signalingLockCheckIntervalMs + 10);
+
+            // We need to wait for the next tick.
+            await Promise.resolve();
+
+            // Verify that the second lock request was sent
+            expect(mockDC.send).toHaveBeenCalledTimes(2);
+
+            // Get the callback for the second attempt
+            const secondLockResponseCb = peer.dcLockResponseCb;
+            expect(secondLockResponseCb).toBeTruthy();
+            expect(secondLockResponseCb).not.toBe(firstLockResponseCb);
+
+            // Resolve the second lock attempt
+            secondLockResponseCb(true);
+
+            // Wait for the second promise to resolve
+            await secondLockPromise;
+
+            // Verify that the callback was cleared
+            expect(peer.dcLockResponseCb).toBeNull();
+        });
+    });
+
+    describe('unlockSignalingLock', () => {
+        it('should send unlock message when data channel is open and negotiated', () => {
+            // Setup
+            peer.dcNegotiated = true;
+            mockDC.readyState = 'open';
+
+            // Call the method
+            peer.unlockSignalingLock();
+
+            // Verify that the unlock message was sent
+            expect(mockDC.send).toHaveBeenCalledTimes(1);
+            expect(dcMsg.encodeDCMsg).toHaveBeenCalledWith(
+                peer.enc,
+                DCMessageType.Unlock,
+            );
+        });
+
+        it('should not send unlock message when data channel is not open', () => {
+            // Setup
+            peer.dcNegotiated = true;
+            mockDC.readyState = 'connecting';
+
+            // Call the method
+            peer.unlockSignalingLock();
+
+            // Verify that no message was sent
+            expect(mockDC.send).not.toHaveBeenCalled();
+        });
+
+        it('should not send unlock message when data channel is not negotiated', () => {
+            // Setup
+            peer.dcNegotiated = false;
+            mockDC.readyState = 'open';
+
+            // Call the method
+            peer.unlockSignalingLock();
+
+            // Verify that no message was sent
+            expect(mockDC.send).not.toHaveBeenCalled();
+        });
+
+        it('should log a warning when data channel is not ready', () => {
+            // Setup
+            peer.dcNegotiated = false;
+            mockDC.readyState = 'connecting';
+
+            // Call the method
+            peer.unlockSignalingLock();
+
+            // Verify that a warning was logged
+            expect(mockConfig.logger.logWarn).toHaveBeenCalledWith(
+                'RTCPeer.unlockSignalingLock: dc not negotiated or not open',
+            );
         });
     });
 });

--- a/src/rtc_peer.ts
+++ b/src/rtc_peer.ts
@@ -2,7 +2,15 @@ import {EventEmitter} from 'events';
 
 import {Encoder, Decoder} from '@msgpack/msgpack';
 
-import {Logger, RTCPeerConfig, RTCTrackOptions, DCMessageType, DCMessageMediaMap} from './types';
+import {
+    Logger,
+    RTCPeerConfig,
+    RTCTrackOptions,
+    DCMessageType,
+    DCMessageMediaMap,
+    DCMessageCodecSupportMap,
+    DCMessageCodecSupportMapDefault,
+} from './types';
 
 import {encodeDCMsg, decodeDCMsg} from './dc_msg';
 
@@ -50,6 +58,8 @@ export class RTCPeer extends EventEmitter {
     public connected: boolean;
 
     private mediaMap: DCMessageMediaMap = {};
+
+    public codecSupportMap: DCMessageCodecSupportMap = DCMessageCodecSupportMapDefault;
 
     constructor(config: RTCPeerConfig) {
         super();
@@ -114,6 +124,10 @@ export class RTCPeer extends EventEmitter {
             case DCMessageType.MediaMap:
                 this.logger.logDebug('RTCPeer.dcHandler: received media map dc message', payload);
                 this.mediaMap = payload as DCMessageMediaMap;
+                break;
+            case DCMessageType.CodecSupportMap:
+                this.logger.logDebug('RTCPeer.dcHandler: received codec support map dc message', payload);
+                this.codecSupportMap = payload as DCMessageCodecSupportMap;
                 break;
             default:
                 this.logger.logWarn(`RTCPeer.dcHandler: unexpected dc message type ${mt}`);

--- a/src/types/dc_msg.ts
+++ b/src/types/dc_msg.ts
@@ -18,6 +18,7 @@ export type DCMessageJitter = number;
 export type TrackInfo = {
     type: string;
     sender_id: string;
+    mime_type: CodecMimeType;
 }
 export type DCMessageMediaMap = {[key: string]: TrackInfo};
 
@@ -28,8 +29,10 @@ export enum CodecSupportLevel {
 }
 export enum CodecMimeType {
     AV1 = 'video/AV1',
+    VP8 = 'video/VP8',
 }
 export type DCMessageCodecSupportMap = {[key in CodecMimeType]: CodecSupportLevel}
 export const DCMessageCodecSupportMapDefault = {
     [CodecMimeType.AV1]: CodecSupportLevel.None,
+    [CodecMimeType.VP8]: CodecSupportLevel.Full,
 };

--- a/src/types/dc_msg.ts
+++ b/src/types/dc_msg.ts
@@ -8,6 +8,7 @@ export enum DCMessageType {
     Lock,
     Unlock,
     MediaMap,
+    CodecSupportMap,
 }
 
 export type DCMessageSDP = Uint8Array;
@@ -20,3 +21,15 @@ export type TrackInfo = {
 }
 export type DCMessageMediaMap = {[key: string]: TrackInfo};
 
+export enum CodecSupportLevel {
+    None = 0,
+    Partial = 1,
+    Full = 2,
+}
+export enum CodecMimeType {
+    AV1 = 'video/AV1',
+}
+export type DCMessageCodecSupportMap = {[key in CodecMimeType]: CodecSupportLevel}
+export const DCMessageCodecSupportMapDefault = {
+    [CodecMimeType.AV1]: CodecSupportLevel.None,
+};

--- a/src/types/webrtc.ts
+++ b/src/types/webrtc.ts
@@ -8,6 +8,7 @@ export type RTCPeerConfig = {
     simulcast?: boolean;
     connTimeoutMs?: number;
     dcSignaling?: boolean;
+    enableAV1?: boolean;
 }
 
 export type SSRCStats = {
@@ -109,6 +110,5 @@ export type RTPEncodingParameters = {
 }
 
 export type RTCTrackOptions = {
-    codec?: RTCRtpCodecCapability;
     encodings?: RTPEncodingParameters[];
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -11,3 +11,8 @@ export function getFirefoxVersion() {
 
     return parseInt(match[1], 10);
 }
+
+export function sleep(ms: number) {
+    return new Promise(resolve => setTimeout(resolve, ms));
+}
+


### PR DESCRIPTION
#### Summary

This PR implements client-side functionality for dynamically controlling video encodings based on call-level support.

Prior to these changes, when AV1 was enabled globally and supported by the sending client, we'd send both an AV1-encoded track and a VP8 track as a fallback. This approach was inefficient, especially considering that newer Firefox versions fully support AV1. This increases the likelihood of complete AV1 support, particularly in smaller calls (e.g., 1-1), making the dual-track sending method wasteful.

In this new approach, we send only one encoding at any time, based on the support level of other participants' clients. Unless all connected clients fully support AV1 (`CodecSupportLevel.Full`), we will send a VP8-encoded track and switch between the two encodings as needed throughout the call's duration.

A new server-side message (`DCMessageCodecSupportMap`) is sent whenever a session leaves or joins, allowing clients to update their encodings if necessary.

I have left comments in specific areas that may need additional attention or consideration.

#### Related PR (server-side changes)

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-63776
