### PR TITLE
Add events 3.3.0 as dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
             "version": "0.27.2",
             "dependencies": {
                 "@msgpack/msgpack": "3.0.0-beta2",
+                "events": "3.3.0",
                 "fflate": "0.8.2",
                 "semver": "7.7.1"
             },
@@ -5429,7 +5430,6 @@
             "version": "3.3.0",
             "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
             "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=0.8.x"

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     },
     "dependencies": {
         "@msgpack/msgpack": "3.0.0-beta2",
+        "events": "3.3.0",
         "fflate": "0.8.2",
         "semver": "7.7.1"
     }


### PR DESCRIPTION
#### Summary
events 3.3.0 is a dependency but was not listed as such in package.json.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-68116
